### PR TITLE
Warn when attaching a URL already on another tack

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,9 +3,9 @@
 Tracking status of the requirements declared in [`spec/v1/SPEC.md`](spec/v1/SPEC.md).
 Updated after each `/spec-audit`.
 
-**Last audit:** 2026-06-24
+**Last audit:** 2026-06-27
 **Spec version:** v1
-**Coverage:** 117 / 117 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts — plus 5 deferred (FUT-01..05)
+**Coverage:** 118 / 118 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts — plus 5 deferred (FUT-01..05)
 
 The HK category (HK-01..05) formalizes the hook layer. AG-02 and HK-04 are now
 **Covered**: the spec was reworded to match what the implementation actually
@@ -26,13 +26,23 @@ at 87; CL-37 makes the already-verified GitHub/GitLab URL detection explicit.
 | DP-01..04 | 4 | All Covered | `src/route.ts` |
 | LK-01 | 1 | Covered | `src/types.ts` |
 | ST-01..06 | 6 | All Covered | `src/route.ts`; ST-06 pins file (`~/.tack/pins.yaml`) |
-| CL-01..47 (+CL-19a, CL-21a..d, CL-36a..d, CL-37a) | 57 | All Covered | includes CL-17/CL-18 (session + `--tack` binding / `--json`), CL-19a (`install-cli`), CL-30..36 (pin/unpin, depends add/rm, status set, rename, move), CL-37 (forge note) + CL-37a (commit-URL label derivation), CL-38 (`--help`/`-h`/`help` + usage exit semantics, incl. subcommand-level `--help`/`-h`, `src/cli.ts`), CL-39/CL-40 (`tack pins` list + prune, `src/route.ts` `listPins`/`prunePins`), CL-41 (group-scoped subcommand errors on stderr, `src/cli.ts` `groupError`, `src/cli.test.ts`), CL-42..47 (`tack repo` lookup/list/alias/prune/rebuild/rm, `src/repos.ts` + `src/cli.ts`) |
+| CL-01..48 (+CL-19a, CL-21a..d, CL-36a..d, CL-37a) | 58 | All Covered | includes CL-17/CL-18 (session + `--tack` binding / `--json`), CL-19a (`install-cli`), CL-30..36 (pin/unpin, depends add/rm, status set, rename, move), CL-37 (forge note) + CL-37a (commit-URL label derivation), CL-38 (`--help`/`-h`/`help` + usage exit semantics, incl. subcommand-level `--help`/`-h`, `src/cli.ts`), CL-39/CL-40 (`tack pins` list + prune, `src/route.ts` `listPins`/`prunePins`), CL-41 (group-scoped subcommand errors on stderr, `src/cli.ts` `groupError`, `src/cli.test.ts`), CL-42..47 (`tack repo` lookup/list/alias/prune/rebuild/rm, `src/repos.ts` + `src/cli.ts`), CL-48 (duplicate-URL warning on attach, `src/route.ts` `findCollisions`, `src/cli.ts` `warnUrlCollision`, `src/cli.test.ts`) |
 | AG-01..11 | 11 | All Covered | AG-02 reworded to drop "without blocking"; AG-10 (auto-pin on confident resolution); AG-11 (early session→tack binding via `tack find`, existing-vs-emerging derivation) covered in `skills/tack/SKILL.md` |
 | HK-01..05 | 5 | All Covered | HK-04 reworded to match the existence-only steps 1/3 the hook runs |
 | RP-01..07 | 7 | All Covered | `~/.tack/repos.yaml` repo database (`src/repos.ts`): RP-02 remote normalization, RP-06 capture from deliverable/link URLs, RP-07 capture from `init`/`pin` cwd origin; tests in `src/repos.test.ts`, `src/cli.test.ts` |
 | FUT-01..05 | 5 | Deferred | Backup feature — out of scope for v1 |
 
 ## Audit history
+
+### 2026-06-27 — Duplicate-URL warning (CL-48)
+
++1 ID (CL-48, issue #10). Attaching a URL as a deliverable or link now scans
+the other tacks for the same exact URL — reusing `find()`'s match rule
+([CL-23]) via `findCollisions` — and warns to stderr when it already lives
+elsewhere, naming each route/tack. The mutated tack is excluded so an
+idempotent re-attach stays quiet; the attach still completes and exits zero.
+`src/route.ts` `findCollisions`, `src/cli.ts` `warnUrlCollision`, tests in
+`src/cli.test.ts`.
 
 ### 2026-06-24 — Repo database (RP category)
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -69,6 +69,15 @@ function expectedOneOf(expected, got) {
     const list = expected.map((s) => `'${s}'`).join(" or ");
     return got ? `expected ${list} (got '${got}')` : `expected ${list}`;
 }
+// Warn (to stderr) when a URL being attached already lives on another tack, so
+// the caller can spot a duplicate before a downstream tool double-counts it.
+function warnUrlCollision(url, slug, tackId) {
+    const collisions = route.findCollisions(url, { slug, tackId });
+    if (collisions.length === 0)
+        return;
+    const locations = collisions.map((m) => `${m.slug}/${m.tackId} (${m.match})`).join(", ");
+    console.error(`warning: url already on ${locations}: ${url}`);
+}
 function resolveSource() {
     // Plugin install: prefer the bash shim that lazy-builds dist on first run.
     const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
@@ -305,6 +314,8 @@ function run() {
                 doneAt: values.date,
                 deliverable,
             });
+            if (deliverableUrl)
+                warnUrlCollision(deliverableUrl, slug, tack.id);
             console.log(formatTack(tack));
             break;
         }
@@ -373,6 +384,7 @@ function run() {
             const dlvUrl = dlvPositionals[2];
             const dlvLabel = dlvValues.label ?? route.deriveDeliverableLabel(dlvUrl);
             const tack = route.setDeliverable(dlvPositionals[0], dlvPositionals[1], dlvLabel, dlvUrl, { force: dlvValues.force });
+            warnUrlCollision(dlvUrl, dlvPositionals[0], tack.id);
             console.log(formatTack(tack));
             break;
         }
@@ -457,6 +469,7 @@ function run() {
                 if (subArgs.length < 4)
                     usage();
                 const tack = route.addLink(subArgs[0], subArgs[1], subArgs[2], subArgs[3]);
+                warnUrlCollision(subArgs[3], subArgs[0], tack.id);
                 console.log(formatTack(tack));
             }
             else if (sub === "rm") {

--- a/dist/cli.test.js
+++ b/dist/cli.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { mkdtempSync, readFileSync } from "node:fs";
@@ -16,6 +16,12 @@ function runFail(args) {
         const err = e;
         return { status: err.status, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
     }
+}
+// Captures stderr regardless of exit code — runFail discards it on success,
+// which hides warnings emitted by commands that still exit 0.
+function runCapture(args) {
+    const r = spawnSync("node", [cli, ...args], { env, encoding: "utf-8" });
+    return { status: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 describe("subcommand-group errors (issue #17)", () => {
     it("link without add/rm names the problem on stderr, not stdout", () => {
@@ -229,5 +235,74 @@ describe("tack start auto-binds the current Claude session (beacon fleet join)",
         execFileSync("node", [cli, "start", "nobind", "t1"], { env: e });
         const yaml = readFileSync(join(home, "routes", "nobind.yaml"), "utf-8");
         assert.doesNotMatch(yaml, /sessions:/);
+    });
+});
+// Tests share a single TACK_HOME and run concurrently, and find() scans every
+// route — so each test uses a distinct URL to keep its collision set isolated.
+describe("duplicate-url warning (issue #10)", () => {
+    it("warns on stderr when a deliverable url is already on another tack", () => {
+        const url = "https://github.com/owner/repo/pull/4201";
+        runFail(["init", "dup-a"]);
+        runFail(["add", "dup-a", "First"]);
+        runFail(["deliverable", "dup-a", "t1", url]);
+        runFail(["init", "dup-b"]);
+        runFail(["add", "dup-b", "Second"]);
+        const r = runCapture(["deliverable", "dup-b", "t1", url]);
+        assert.equal(r.status, 0);
+        assert.match(r.stderr, /warning: url already on dup-a\/t1 \(deliverable\)/);
+        assert.match(r.stderr, new RegExp(url.replace(/[/.]/g, "\\$&")));
+    });
+    it("warns when a link url is already on another tack", () => {
+        const url = "https://github.com/owner/repo/pull/4202";
+        runFail(["init", "dup-link-a"]);
+        runFail(["add", "dup-link-a", "First"]);
+        runFail(["link", "add", "dup-link-a", "t1", "issue", url]);
+        runFail(["init", "dup-link-b"]);
+        runFail(["add", "dup-link-b", "Second"]);
+        const r = runCapture(["link", "add", "dup-link-b", "t1", "issue", url]);
+        assert.equal(r.status, 0);
+        assert.match(r.stderr, /warning: url already on dup-link-a\/t1 \(link\)/);
+    });
+    it("warns from add --deliverable when the url is already attached", () => {
+        const url = "https://github.com/owner/repo/pull/4203";
+        runFail(["init", "dup-add-a"]);
+        runFail(["add", "dup-add-a", "First", "--deliverable", url]);
+        const r = runCapture(["add", "dup-add-a", "Second", "--deliverable", url]);
+        assert.equal(r.status, 0);
+        assert.match(r.stderr, /warning: url already on dup-add-a\/t1 \(deliverable\)/);
+    });
+    it("does not warn on an idempotent re-attach to the same tack", () => {
+        const url = "https://github.com/owner/repo/pull/4204";
+        runFail(["init", "dup-self"]);
+        runFail(["add", "dup-self", "Work"]);
+        runFail(["deliverable", "dup-self", "t1", url]);
+        // Re-attaching the same url to the same tack overwrites with --force; the
+        // mutated tack is excluded from the collision scan, so no warning fires.
+        const r = runCapture(["deliverable", "dup-self", "t1", url, "--force"]);
+        assert.equal(r.status, 0);
+        assert.doesNotMatch(r.stderr, /warning: url already on/);
+    });
+    it("does not warn when the url is new", () => {
+        const url = "https://github.com/owner/repo/pull/4205";
+        runFail(["init", "dup-new"]);
+        runFail(["add", "dup-new", "Work"]);
+        const r = runCapture(["deliverable", "dup-new", "t1", url]);
+        assert.equal(r.status, 0);
+        assert.doesNotMatch(r.stderr, /warning: url already on/);
+    });
+    it("names multiple existing tacks when the url is on several", () => {
+        const url = "https://github.com/owner/repo/pull/4206";
+        runFail(["init", "dup-multi-a"]);
+        runFail(["add", "dup-multi-a", "First"]);
+        runFail(["deliverable", "dup-multi-a", "t1", url]);
+        runFail(["init", "dup-multi-b"]);
+        runFail(["add", "dup-multi-b", "Second"]);
+        runFail(["link", "add", "dup-multi-b", "t1", "ref", url]);
+        runFail(["init", "dup-multi-c"]);
+        runFail(["add", "dup-multi-c", "Third"]);
+        const r = runCapture(["deliverable", "dup-multi-c", "t1", url]);
+        assert.equal(r.status, 0);
+        assert.match(r.stderr, /dup-multi-a\/t1 \(deliverable\)/);
+        assert.match(r.stderr, /dup-multi-b\/t1 \(link\)/);
     });
 });

--- a/dist/route.d.ts
+++ b/dist/route.d.ts
@@ -75,6 +75,10 @@ export interface FindMatch {
     url: string;
 }
 export declare function find(url: string): FindMatch[];
+export declare function findCollisions(url: string, exclude: {
+    slug: string;
+    tackId: string;
+}): FindMatch[];
 export declare function rebuildRepos(): repos.RebuildResult;
 export declare function remove(slug: string): void;
 export interface Pin {

--- a/dist/route.js
+++ b/dist/route.js
@@ -565,6 +565,12 @@ export function find(url) {
     }
     return matches;
 }
+// Return every tack that already references this URL, excluding the tack being
+// mutated (so an idempotent re-attach to the same tack does not count as a
+// collision). Reuses find()'s exact-URL matching — same rule as `tack find`.
+export function findCollisions(url, exclude) {
+    return find(url).filter((m) => !(m.slug === exclude.slug && m.tackId === exclude.tackId));
+}
 // CL-47: backfill the repo database from existing tack data — every forge URL
 // recorded on a route plus every pinned directory's origin remote.
 export function rebuildRepos() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,12 @@ the existing label and URL — this prevents a typo'd tack ID from silently
 clobbering an unrelated tack's deliverable. Pass `--force` to overwrite
 intentionally.
 
+If the URL is already attached to another tack (as a deliverable or link), the
+command prints a `warning: url already on <route>/<tack> ...` to stderr naming
+where it lives, so you can spot a duplicate before a downstream tool
+double-counts the work. The attach still completes — the warning is
+informational. Re-attaching a URL already on the same tack does not warn.
+
 ```bash
 tack deliverable auth-rewrite t1 https://github.com/org/repo/pull/42            # label → "repo#42"
 tack deliverable auth-rewrite t1 https://github.com/org/repo/pull/42 --label "Session PR"
@@ -377,6 +383,10 @@ tack todo rm auth-rewrite t1 a2
 Add a reference link to a tack. The URL is always recorded as a link —
 even when it points at a PR/MR — so links and deliverables stay
 explicit. Use `tack deliverable` to set the change request directly.
+
+If the URL is already attached to another tack, the command prints a
+`warning: url already on ...` to stderr (see `tack deliverable`). The link is
+still added.
 
 ```bash
 tack link add auth-rewrite t1 "Design doc" https://docs.example.com/auth

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -622,6 +622,16 @@ pinned directory's `origin` remote ([RP-07]). The rebuild is additive — it add
 names and locals but removes nothing, so custom aliases ([CL-44]) survive a
 re-run. It backfills the database for routes recorded before capture existed.
 
+**[CL-48]** Duplicate-URL warning — When a URL is attached as a deliverable
+(`tack add --deliverable`, `tack deliverable`) or a link (`tack link add`),
+the CLI shall check whether the same URL already appears as a deliverable or
+link on any other tack (the same exact-URL match as `tack find`, [CL-23]), and
+if so shall print a warning to stderr that names the existing route(s) and tack
+id(s) with a `warning: url already on ` prefix. The tack being mutated is
+excluded, so re-attaching a URL already present on that same tack does not
+warn. The warning is informational: the attach still completes and the command
+exits zero.
+
 ---
 
 ### AG — Agent Integration

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { mkdtempSync, readFileSync } from "node:fs";
@@ -17,6 +17,13 @@ function runFail(args: string[]): { status: number; stdout: string; stderr: stri
     const err = e as { status: number; stdout?: string; stderr?: string };
     return { status: err.status, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
   }
+}
+
+// Captures stderr regardless of exit code — runFail discards it on success,
+// which hides warnings emitted by commands that still exit 0.
+function runCapture(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("node", [cli, ...args], { env, encoding: "utf-8" });
+  return { status: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 
 describe("subcommand-group errors (issue #17)", () => {
@@ -258,5 +265,80 @@ describe("tack start auto-binds the current Claude session (beacon fleet join)",
     execFileSync("node", [cli, "start", "nobind", "t1"], { env: e });
     const yaml = readFileSync(join(home, "routes", "nobind.yaml"), "utf-8");
     assert.doesNotMatch(yaml, /sessions:/);
+  });
+});
+
+// Tests share a single TACK_HOME and run concurrently, and find() scans every
+// route — so each test uses a distinct URL to keep its collision set isolated.
+describe("duplicate-url warning (issue #10)", () => {
+  it("warns on stderr when a deliverable url is already on another tack", () => {
+    const url = "https://github.com/owner/repo/pull/4201";
+    runFail(["init", "dup-a"]);
+    runFail(["add", "dup-a", "First"]);
+    runFail(["deliverable", "dup-a", "t1", url]);
+    runFail(["init", "dup-b"]);
+    runFail(["add", "dup-b", "Second"]);
+    const r = runCapture(["deliverable", "dup-b", "t1", url]);
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /warning: url already on dup-a\/t1 \(deliverable\)/);
+    assert.match(r.stderr, new RegExp(url.replace(/[/.]/g, "\\$&")));
+  });
+
+  it("warns when a link url is already on another tack", () => {
+    const url = "https://github.com/owner/repo/pull/4202";
+    runFail(["init", "dup-link-a"]);
+    runFail(["add", "dup-link-a", "First"]);
+    runFail(["link", "add", "dup-link-a", "t1", "issue", url]);
+    runFail(["init", "dup-link-b"]);
+    runFail(["add", "dup-link-b", "Second"]);
+    const r = runCapture(["link", "add", "dup-link-b", "t1", "issue", url]);
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /warning: url already on dup-link-a\/t1 \(link\)/);
+  });
+
+  it("warns from add --deliverable when the url is already attached", () => {
+    const url = "https://github.com/owner/repo/pull/4203";
+    runFail(["init", "dup-add-a"]);
+    runFail(["add", "dup-add-a", "First", "--deliverable", url]);
+    const r = runCapture(["add", "dup-add-a", "Second", "--deliverable", url]);
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /warning: url already on dup-add-a\/t1 \(deliverable\)/);
+  });
+
+  it("does not warn on an idempotent re-attach to the same tack", () => {
+    const url = "https://github.com/owner/repo/pull/4204";
+    runFail(["init", "dup-self"]);
+    runFail(["add", "dup-self", "Work"]);
+    runFail(["deliverable", "dup-self", "t1", url]);
+    // Re-attaching the same url to the same tack overwrites with --force; the
+    // mutated tack is excluded from the collision scan, so no warning fires.
+    const r = runCapture(["deliverable", "dup-self", "t1", url, "--force"]);
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stderr, /warning: url already on/);
+  });
+
+  it("does not warn when the url is new", () => {
+    const url = "https://github.com/owner/repo/pull/4205";
+    runFail(["init", "dup-new"]);
+    runFail(["add", "dup-new", "Work"]);
+    const r = runCapture(["deliverable", "dup-new", "t1", url]);
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stderr, /warning: url already on/);
+  });
+
+  it("names multiple existing tacks when the url is on several", () => {
+    const url = "https://github.com/owner/repo/pull/4206";
+    runFail(["init", "dup-multi-a"]);
+    runFail(["add", "dup-multi-a", "First"]);
+    runFail(["deliverable", "dup-multi-a", "t1", url]);
+    runFail(["init", "dup-multi-b"]);
+    runFail(["add", "dup-multi-b", "Second"]);
+    runFail(["link", "add", "dup-multi-b", "t1", "ref", url]);
+    runFail(["init", "dup-multi-c"]);
+    runFail(["add", "dup-multi-c", "Third"]);
+    const r = runCapture(["deliverable", "dup-multi-c", "t1", url]);
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /dup-multi-a\/t1 \(deliverable\)/);
+    assert.match(r.stderr, /dup-multi-b\/t1 \(link\)/);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,15 @@ function expectedOneOf(expected: string[], got: string | undefined): string {
   return got ? `expected ${list} (got '${got}')` : `expected ${list}`;
 }
 
+// Warn (to stderr) when a URL being attached already lives on another tack, so
+// the caller can spot a duplicate before a downstream tool double-counts it.
+function warnUrlCollision(url: string, slug: string, tackId: string): void {
+  const collisions = route.findCollisions(url, { slug, tackId });
+  if (collisions.length === 0) return;
+  const locations = collisions.map((m) => `${m.slug}/${m.tackId} (${m.match})`).join(", ");
+  console.error(`warning: url already on ${locations}: ${url}`);
+}
+
 type Source = { path: string; kind: "shim" | "node" };
 
 function resolveSource(): Source {
@@ -328,6 +337,7 @@ function run(): void {
         doneAt: values.date as string | undefined,
         deliverable,
       });
+      if (deliverableUrl) warnUrlCollision(deliverableUrl, slug, tack.id);
       console.log(formatTack(tack));
       break;
     }
@@ -404,6 +414,7 @@ function run(): void {
         dlvUrl,
         { force: dlvValues.force as boolean | undefined },
       );
+      warnUrlCollision(dlvUrl, dlvPositionals[0], tack.id);
       console.log(formatTack(tack));
       break;
     }
@@ -487,6 +498,7 @@ function run(): void {
       if (sub === "add") {
         if (subArgs.length < 4) usage();
         const tack = route.addLink(subArgs[0], subArgs[1], subArgs[2], subArgs[3]);
+        warnUrlCollision(subArgs[3], subArgs[0], tack.id);
         console.log(formatTack(tack));
       } else if (sub === "rm") {
         if (subArgs.length < 3) usage();

--- a/src/route.ts
+++ b/src/route.ts
@@ -705,6 +705,18 @@ export function find(url: string): FindMatch[] {
   return matches;
 }
 
+// Return every tack that already references this URL, excluding the tack being
+// mutated (so an idempotent re-attach to the same tack does not count as a
+// collision). Reuses find()'s exact-URL matching — same rule as `tack find`.
+export function findCollisions(
+  url: string,
+  exclude: { slug: string; tackId: string },
+): FindMatch[] {
+  return find(url).filter(
+    (m) => !(m.slug === exclude.slug && m.tackId === exclude.tackId),
+  );
+}
+
 // CL-47: backfill the repo database from existing tack data — every forge URL
 // recorded on a route plus every pinned directory's origin remote.
 export function rebuildRepos(): repos.RebuildResult {


### PR DESCRIPTION
## Context

Each tack records its shipped work as a deliverable or link URL, and downstream tools read those URLs to count work — a `/wip` dashboard, the YTD metrics. Attaching a URL that already lived on another tack was accepted with no signal, so the same PR/commit could sit on two tacks and get counted twice. This isn't hypothetical: a recent audit of the route DB turned up three merge requests each attached as the deliverable on two different tacks.

This adds an attach-time heads-up. `tack add --deliverable`, `tack deliverable`, and `tack link add` now scan the other tacks for the same exact URL and print `warning: url already on <route>/<tack> …` to stderr, naming where it already lives. It's informational, not a gate — the attach completes and the command exits zero. Re-attaching a URL already on the same tack stays quiet.

Closes #10 and #20.

## Review guide

- **The scan** — [`findCollisions`](https://github.com/chris-peterson/tack/pull/22/files#diff-634333527025d8043fae2cc51a501b3e6cc4a200276c061bcaa0a947b0e9c3f1R711) reuses `find()`'s exact-URL match (the same rule as `tack find`, `CL-23`) and filters out the tack being mutated, so an idempotent re-attach doesn't flag itself.
- **The warning** — [`warnUrlCollision`](https://github.com/chris-peterson/tack/pull/22/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR79) formats the hits and writes to stderr. Wired into the three attach paths: [`add --deliverable`](https://github.com/chris-peterson/tack/pull/22/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR340), [`deliverable`](https://github.com/chris-peterson/tack/pull/22/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR417), [`link add`](https://github.com/chris-peterson/tack/pull/22/files#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR501).
- **Spec + docs** — [`CL-48`](https://github.com/chris-peterson/tack/pull/22/files#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R625) is the normative behavior; `STATUS.md` and `docs/cli.md` track it.
- **Tests** — the [duplicate-url suite](https://github.com/chris-peterson/tack/pull/22/files#diff-c6e5a65515030fb8ae1e75a91c25524498f612d5ce26ba2115a334e7974df5e6R273) covers deliverable / link / `add --deliverable` collisions, idempotent re-attach and a brand-new URL (both quiet), and multi-tack naming. A `runCapture` helper captures stderr on exit 0, which the existing `runFail` discards.
