### PR TITLE
Bind current session on tack start

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -312,6 +312,13 @@ function run() {
             if (!rest[0] || !rest[1])
                 usage();
             const tack = route.startTack(rest[0], rest[1]);
+            // Bind the current Claude session to the tack it just started, so the
+            // fleet view (beacon reads sessions[].tacks) attributes the session to
+            // the tack it is driving with no separate `tack session --tack` call.
+            // No-op in an ad-hoc terminal where the session env var is unset.
+            const startSid = process.env.CLAUDE_CODE_SESSION_ID;
+            if (startSid)
+                route.recordSession(rest[0], startSid, rest[1]);
             console.log(formatTack(tack));
             break;
         }

--- a/dist/cli.test.js
+++ b/dist/cli.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 const cli = join(dirname(fileURLToPath(import.meta.url)), "cli.js");
 const env = { ...process.env, TACK_HOME: mkdtempSync(join(tmpdir(), "tack-cli-test-")) };
@@ -206,5 +206,28 @@ describe("--help after a subcommand shows usage", () => {
         const r = runFail(["session", "-h"]);
         assert.equal(r.status, 0);
         assert.match(r.stdout, /Usage:/);
+    });
+});
+describe("tack start auto-binds the current Claude session (beacon fleet join)", () => {
+    it("records the session with the started tack under sessions[]", () => {
+        const home = mkdtempSync(join(tmpdir(), "tack-start-bind-"));
+        const e = { ...process.env, TACK_HOME: home, CLAUDE_CODE_SESSION_ID: "sess-abc-123" };
+        execFileSync("node", [cli, "init", "bindroute"], { env: e });
+        execFileSync("node", [cli, "add", "bindroute", "Wire it"], { env: e });
+        execFileSync("node", [cli, "start", "bindroute", "t1"], { env: e });
+        const yaml = readFileSync(join(home, "routes", "bindroute.yaml"), "utf-8");
+        assert.match(yaml, /sessions:/);
+        assert.match(yaml, /- id: sess-abc-123/);
+        assert.match(yaml, /tacks:\s*\n\s*- t1/);
+    });
+    it("is a no-op outside a Claude session (env var unset)", () => {
+        const home = mkdtempSync(join(tmpdir(), "tack-start-nobind-"));
+        const e = { ...process.env, TACK_HOME: home };
+        delete e.CLAUDE_CODE_SESSION_ID;
+        execFileSync("node", [cli, "init", "nobind"], { env: e });
+        execFileSync("node", [cli, "add", "nobind", "Wire it"], { env: e });
+        execFileSync("node", [cli, "start", "nobind", "t1"], { env: e });
+        const yaml = readFileSync(join(home, "routes", "nobind.yaml"), "utf-8");
+        assert.doesNotMatch(yaml, /sessions:/);
     });
 });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,6 +213,12 @@ names two ways forward:
 tack start auth-rewrite t1
 ```
 
+When run inside a Claude Code session (the `CLAUDE_CODE_SESSION_ID`
+environment variable is set), `start` also binds that session to the tack —
+the same link `tack session <slug> <session-id> --tack <tack-id>` writes.
+That's what lets the fleet view (beacon) show which tack a session is
+driving, with nothing extra to run. Outside a Claude session it's a no-op.
+
 ### `tack status set <slug> <tack-id> <status>`
 
 Set a tack's status directly, with no guards. Valid statuses: `pending`,

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -323,7 +323,13 @@ entries with unmet dependencies, the operation shall fail per [DP-03]. The
 error message shall guide the user to either drop the edge with
 [CL-33] (`tack depends rm`) when the declared ordering no longer holds, or
 to bypass the guard with [CL-34] (`tack status set`) when the inconsistent
-state is intentional.
+state is intentional. When the `CLAUDE_CODE_SESSION_ID` environment variable
+is set (the CLI is running inside a Claude Code session), the CLI shall also
+bind that session to the started tack per [RT-11] / [CL-17] — starting a tack
+in a session is the declaration that the session is driving it, so a fleet
+reader keyed on the Claude session id (e.g. beacon) can attribute the session
+to the tack with no separate `tack session --tack` call. Outside a Claude
+session (variable unset) this is a no-op.
 
 **[CL-08]** `tack deliverable <slug> <tack-id> <url> [--label <text>] [--force]` —
 When invoked, the CLI shall set the deliverable on the specified tack. The

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 
 const cli = join(dirname(fileURLToPath(import.meta.url)), "cli.js");
@@ -233,5 +233,30 @@ describe("--help after a subcommand shows usage", () => {
     const r = runFail(["session", "-h"]);
     assert.equal(r.status, 0);
     assert.match(r.stdout, /Usage:/);
+  });
+});
+
+describe("tack start auto-binds the current Claude session (beacon fleet join)", () => {
+  it("records the session with the started tack under sessions[]", () => {
+    const home = mkdtempSync(join(tmpdir(), "tack-start-bind-"));
+    const e = { ...process.env, TACK_HOME: home, CLAUDE_CODE_SESSION_ID: "sess-abc-123" };
+    execFileSync("node", [cli, "init", "bindroute"], { env: e });
+    execFileSync("node", [cli, "add", "bindroute", "Wire it"], { env: e });
+    execFileSync("node", [cli, "start", "bindroute", "t1"], { env: e });
+    const yaml = readFileSync(join(home, "routes", "bindroute.yaml"), "utf-8");
+    assert.match(yaml, /sessions:/);
+    assert.match(yaml, /- id: sess-abc-123/);
+    assert.match(yaml, /tacks:\s*\n\s*- t1/);
+  });
+
+  it("is a no-op outside a Claude session (env var unset)", () => {
+    const home = mkdtempSync(join(tmpdir(), "tack-start-nobind-"));
+    const e: NodeJS.ProcessEnv = { ...process.env, TACK_HOME: home };
+    delete e.CLAUDE_CODE_SESSION_ID;
+    execFileSync("node", [cli, "init", "nobind"], { env: e });
+    execFileSync("node", [cli, "add", "nobind", "Wire it"], { env: e });
+    execFileSync("node", [cli, "start", "nobind", "t1"], { env: e });
+    const yaml = readFileSync(join(home, "routes", "nobind.yaml"), "utf-8");
+    assert.doesNotMatch(yaml, /sessions:/);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -335,6 +335,12 @@ function run(): void {
     case "start": {
       if (!rest[0] || !rest[1]) usage();
       const tack = route.startTack(rest[0], rest[1]);
+      // Bind the current Claude session to the tack it just started, so the
+      // fleet view (beacon reads sessions[].tacks) attributes the session to
+      // the tack it is driving with no separate `tack session --tack` call.
+      // No-op in an ad-hoc terminal where the session env var is unset.
+      const startSid = process.env.CLAUDE_CODE_SESSION_ID;
+      if (startSid) route.recordSession(rest[0], startSid, rest[1]);
       console.log(formatTack(tack));
       break;
     }


### PR DESCRIPTION
## Why

The beacon fleet view attributes each session to the tack it's driving by reading the route's `sessions[].tacks[]` link (RT-11). Nothing wrote that link outside an explicit `tack session --tack`, so in practice sessions were never bound to a tack and the fleet view showed nothing — even for in-progress work on a tracked tack.

## What

`tack start <slug> <tack-id>` now also binds the current Claude session to the tack when `CLAUDE_CODE_SESSION_ID` is set. Starting a tack in a session *is* the declaration that the session is driving it, so the link the fleet view needs is created automatically — no separate `tack session --tack` call. A no-op in an ad-hoc terminal where the variable is unset.

- `src/cli.ts` — `start` records the session (via the existing `recordSession`) when the env var is present.
- `spec/v1/SPEC.md` — CL-07 updated.
- `docs/cli.md` — the `start` entry documents the behavior.
- Tests — CLI-level coverage for both the bind and the no-op-when-unset paths (213 pass).

`plugin.yml` / `CHANGELOG.md` are intentionally untouched — the release workflow owns the version bump and proxies the release notes into the changelog.
