### PR TITLE
spec category rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@ Fixes session→tack binding, which silently did nothing because the code and th
 
 ### Features
 
-- **Sessions link to the specific tack they're driving.** `tack session <slug> <session-id> --tack <tack-id>` binds a session to a tack within the route, stored as a `tacks` array on the session entry (touch order, last = current focus). A session was previously associated only with a route, so a fleet view could group live sessions by route but not show which tack each one was working. Re-binding a tack moves it to the end, so a pivot back to an earlier tack makes it current again (RTE-11, CLI-17).
+- **Sessions link to the specific tack they're driving.** `tack session <slug> <session-id> --tack <tack-id>` binds a session to a tack within the route, stored as a `tacks` array on the session entry (touch order, last = current focus). A session was previously associated only with a route, so a fleet view could group live sessions by route but not show which tack each one was working. Re-binding a tack moves it to the end, so a pivot back to an earlier tack makes it current again (ROUTE-11, CLI-17).
 - **The skill establishes the session→tack link early from a tracker URL.** When a PR/MR/issue URL is in scope at session start, the tack skill runs `tack find` on it — a match binds the session to the existing tack, no match means emerging work (create the tack, then bind) — so a dashboard can tell resumed/tracked work from work spun up fresh in the session. Whether work is existing or emerging is read off the bound tack's own state (does it carry a deliverable or tracker link?), not stored as a flag (AGT-11).
 
 ## 0.17.0
@@ -258,7 +258,7 @@ Closes #1.
 - New `tack pin <slug>` / `tack unpin` commands persist the active route for a working directory in a `.tack` YAML file at the cwd root. The tack skill reads the pin first when resolving "what am I working on?", so pinned routes win over branch-slug or single-open-route heuristics. Commit the file for shared assignment or `.gitignore` it for per-dev state.
 
 ### Architecture
-- Spec now states the layering explicitly: the CLI encapsulates schema operations as a deterministic primitive; the skill owns reasoning (route resolution, ambiguity prompts, URL capture); hooks emit advisory reminders. The CLI no longer reaches into inference — that lives entirely in `skills/tack/SKILL.md`. New `[STG-06]` covers the pin file format; new `[CLI-30]`/`[CLI-31]` cover the pin/unpin commands; AG- expanded with a formal resolution procedure (`[AGT-03]`) and pin discipline (`[AGT-10]`); new **HK** category formalizes what each hook does.
+- Spec now states the layering explicitly: the CLI encapsulates schema operations as a deterministic primitive; the skill owns reasoning (route resolution, ambiguity prompts, URL capture); hooks emit advisory reminders. The CLI no longer reaches into inference — that lives entirely in `skills/tack/SKILL.md`. New `[STORE-06]` covers the pin file format; new `[CLI-30]`/`[CLI-31]` cover the pin/unpin commands; AG- expanded with a formal resolution procedure (`[AGT-03]`) and pin discipline (`[AGT-10]`); new **HK** category formalizes what each hook does.
 - Hook reminder text now points at the tack skill rather than naming specific CLI commands, routing all writes through one path (the skill) so context (which slug, which tack) is applied by the only component that sees it.
 
 ## 0.9.1

--- a/SPEC.md
+++ b/SPEC.md
@@ -60,13 +60,13 @@ Route (1 YAML file per route)
 
 | Category | Description |
 |---|---|
-| RTE | Route schema structure and constraints |
+| ROUTE | Route schema structure and constraints |
 | TACK | Tack fields, statuses, and ID sequencing |
 | DEL | Deliverable (single change request per tack) |
 | TODO | Todo items (before/after arrays with IDs) |
 | DEP | Dependency tracking and enforcement |
 | LINK | Link structure (label + url) |
-| STG | Storage location, directory creation, validation, cwd pointer file |
+| STORE | Storage location, directory creation, validation, cwd pointer file |
 | CLI | CLI commands and output behavior |
 | AGT | Claude Code agent integration (skill responsibilities) |
 | HOOK | Hook responsibilities (nudges, freshness checks) |

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ Updated after each `/sextant:spec-status` or `/sextant:spec-sync` run.
 
 **Last audit:** 2026-08-04
 **Spec version:** v1
-**Coverage:** 134 / 134 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts — plus 5 deferred (FUT-01..05)
+**Coverage:** 134 / 134 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts
 
 This `/sextant:spec-sync` pass captured one drift item: the new
 `tack merge-routes` command (issue #8) shipped without a requirement. Added as
@@ -20,24 +20,37 @@ Source-verified count moves 122 → 127.
 
 | Prefix | Count | Status | Notes |
 |--------|------:|--------|-------|
-| RTE-01..11 (routes) | 11 | All Covered | `src/types.ts`, `schema/route.schema.json`, `src/route.ts`; RTE-04 optional fields now include `title`/`description` (`Route` in `src/types.ts`, rendered by `formatRoute` in `src/display.ts`); includes RTE-09/RTE-10 sessions and RTE-11 session→tack binding (`Session.tacks`) |
+| ROUTE-01..11 (routes) | 11 | All Covered | `src/types.ts`, `schema/route.schema.json`, `src/route.ts`; ROUTE-04 optional fields now include `title`/`description` (`Route` in `src/types.ts`, rendered by `formatRoute` in `src/display.ts`); includes ROUTE-09/ROUTE-10 sessions and ROUTE-11 session→tack binding (`Session.tacks`) |
 | TACK-01..08 (tacks) | 8 | All Covered | `src/route.ts`; TACK-08 bare-id resolution (`normalizeTackId`) |
 | DEL-01..02 (deliverables) | 2 | All Covered | `src/types.ts`, `src/route.ts` |
 | TODO-01..05 (todos) | 5 | All Covered | `src/route.ts`; TODO-01 reworded to shall form |
 | DEP-01..04 (dependencies) | 4 | All Covered | `src/route.ts` |
 | LINK-01 (links) | 1 | Covered | `src/types.ts` |
-| STG-01..08 (storage) | 8 | All Covered | `src/route.ts`; STG-06 pins file (`~/.tack/pins.yaml`); STG-07 filename↔`slug` agreement enforced in `load`; STG-08 boundary slug checks (`assertValidSlug`, called from `init`, `rename`, `setGroup`, `mergeRoutes`), tests in `src/route.test.ts` |
-| CLI-01..54 (commands; +CLI-08a, CLI-19a, CLI-21a..d, CLI-23a..b, CLI-36a..d, CLI-37a, CLI-52a..d, CLI-54a) | 72 | All Covered | CLI-53/CLI-54/CLI-54a (`tack title` and `tack describe` show/set/clear, plus `describe`'s `--file <path>` / `--file -` body input, trailing-newline stripping, and the empty-body refusal — `title`/`describe` dispatch and `readDescriptionBody` in `src/cli.ts`, `setTitle`/`clearTitle`/`setDescription`/`clearDescription` in `src/route.ts`, tests in `src/cli.test.ts`/`src/route.test.ts`); CLI-14 carries the route `title` in the text listing (`list` in `src/route.ts`, `formatList` in `src/display.ts`), while the `--json` form serializes the full route (`loadAll` in `src/route.ts`); CLI-52c title/description carry-over on merge (`mergeRoutes` in `src/route.ts`); CLI-23a/CLI-23b (`tack find --path` path lookup and the exactly-one `--url`/`--path` selector guard — `repoKeyForCwd` in `src/repos.ts`, `findByRepoKey` in `src/route.ts`, `find` dispatch in `src/cli.ts`, tests in `src/route.test.ts`/`src/cli.test.ts`); CLI-52 (`tack merge-routes`, whole-route consolidation with chronological destination IDs, metadata/`depends_on`/session preservation, `created_at`/group defaults, external route-dep guard — `mergeRoutes` in `src/route.ts`, `merge-routes` dispatch in `src/cli.ts`, tests in `src/route.test.ts`); CLI-51 (`tack group` show/set/clear, `src/cli.ts` group case + `setGroup`/`clearGroup` in `src/route.ts`); also includes CLI-02/CLI-04 (`init`/`add` record the current session route-level via `recordSessionIfPresent`, `src/cli.ts`; CLI-04 also takes repeatable `--link "label,url"`, deduped in `addTack`), CLI-08a (`deliverable rm` clears or `--to-link`-demotes the deliverable, `src/route.ts` `removeDeliverable` + `src/cli.ts` dispatch, tests in `src/route.test.ts`/`src/cli.test.ts`), CLI-17/CLI-18 (session + `--tack` binding / `--json`), CLI-19a (`install-cli`), CLI-30..36 (pin/unpin, depends add/rm, status set, rename, move), CLI-37 (forge note) + CLI-37a (commit-URL label derivation), CLI-38 (`--help`/`-h`/`help` + usage exit semantics, incl. subcommand-level `--help`/`-h`, `src/cli.ts`), CLI-39/CLI-40 (`tack pins` list + prune, `src/route.ts` `listPins`/`prunePins`), CLI-41 (group-scoped subcommand errors on stderr, `src/cli.ts` `groupError`, `src/cli.test.ts`), CLI-42..47 (`tack repo` lookup/list/alias/prune/rebuild/rm, `src/repos.ts` + `src/cli.ts`), CLI-48 (duplicate-URL warning on attach, `src/route.ts` `findCollisions`, `src/cli.ts` `warnUrlCollision`, `src/cli.test.ts`), CLI-49/CLI-50 (`export` to stdout by default with `--out-file`/`--compress`, `import` detecting gzip-vs-plain by content, schema versioning + identity-dedup merge, `src/backup.ts` + `src/cli.ts`, `src/cli.test.ts`); CLI-04 `--link` splits at the first comma whose suffix parses as a URL (commas allowed in label and URL), CLI-15 `rm` refusal on stderr with a non-zero exit, CLI-51 group checked at the boundary per STG-08 — all three reworded, no new IDs |
+| STORE-01..08 (storage) | 8 | All Covered | `src/route.ts`; STORE-06 pins file (`~/.tack/pins.yaml`); STORE-07 filename↔`slug` agreement enforced in `load`; STORE-08 boundary slug checks (`assertValidSlug`, called from `init`, `rename`, `setGroup`, `mergeRoutes`), tests in `src/route.test.ts` |
+| CLI-01..54 (commands; +CLI-08a, CLI-19a, CLI-21a..d, CLI-23a..b, CLI-36a..d, CLI-37a, CLI-52a..d, CLI-54a) | 72 | All Covered | CLI-53/CLI-54/CLI-54a (`tack title` and `tack describe` show/set/clear, plus `describe`'s `--file <path>` / `--file -` body input, trailing-newline stripping, and the empty-body refusal — `title`/`describe` dispatch and `readDescriptionBody` in `src/cli.ts`, `setTitle`/`clearTitle`/`setDescription`/`clearDescription` in `src/route.ts`, tests in `src/cli.test.ts`/`src/route.test.ts`); CLI-14 carries the route `title` in the text listing (`list` in `src/route.ts`, `formatList` in `src/display.ts`), while the `--json` form serializes the full route (`loadAll` in `src/route.ts`); CLI-52c title/description carry-over on merge (`mergeRoutes` in `src/route.ts`); CLI-23a/CLI-23b (`tack find --path` path lookup and the exactly-one `--url`/`--path` selector guard — `repoKeyForCwd` in `src/repos.ts`, `findByRepoKey` in `src/route.ts`, `find` dispatch in `src/cli.ts`, tests in `src/route.test.ts`/`src/cli.test.ts`); CLI-52 (`tack merge-routes`, whole-route consolidation with chronological destination IDs, metadata/`depends_on`/session preservation, `created_at`/group defaults, external route-dep guard — `mergeRoutes` in `src/route.ts`, `merge-routes` dispatch in `src/cli.ts`, tests in `src/route.test.ts`); CLI-51 (`tack group` show/set/clear, `src/cli.ts` group case + `setGroup`/`clearGroup` in `src/route.ts`); also includes CLI-02/CLI-04 (`init`/`add` record the current session route-level via `recordSessionIfPresent`, `src/cli.ts`; CLI-04 also takes repeatable `--link "label,url"`, deduped in `addTack`), CLI-08a (`deliverable rm` clears or `--to-link`-demotes the deliverable, `src/route.ts` `removeDeliverable` + `src/cli.ts` dispatch, tests in `src/route.test.ts`/`src/cli.test.ts`), CLI-17/CLI-18 (session + `--tack` binding / `--json`), CLI-19a (`install-cli`), CLI-30..36 (pin/unpin, depends add/rm, status set, rename, move), CLI-37 (forge note) + CLI-37a (commit-URL label derivation), CLI-38 (`--help`/`-h`/`help` + usage exit semantics, incl. subcommand-level `--help`/`-h`, `src/cli.ts`), CLI-39/CLI-40 (`tack pins` list + prune, `src/route.ts` `listPins`/`prunePins`), CLI-41 (group-scoped subcommand errors on stderr, `src/cli.ts` `groupError`, `src/cli.test.ts`), CLI-42..47 (`tack repo` lookup/list/alias/prune/rebuild/rm, `src/repos.ts` + `src/cli.ts`), CLI-48 (duplicate-URL warning on attach, `src/route.ts` `findCollisions`, `src/cli.ts` `warnUrlCollision`, `src/cli.test.ts`), CLI-49/CLI-50 (`export` to stdout by default with `--out-file`/`--compress`, `import` detecting gzip-vs-plain by content, schema versioning + identity-dedup merge, `src/backup.ts` + `src/cli.ts`, `src/cli.test.ts`); CLI-04 `--link` splits at the first comma whose suffix parses as a URL (commas allowed in label and URL), CLI-15 `rm` refusal on stderr with a non-zero exit, CLI-51 group checked at the boundary per STORE-08 — all three reworded, no new IDs |
 | AGT-01..11 (agent) | 11 | All Covered | AGT-02 reworded to drop "without blocking"; AGT-10 (auto-pin on confident resolution); AGT-11 (early session→tack binding via `tack find`, existing-vs-emerging derivation) covered in `skills/tack/SKILL.md` |
 | HOOK-01..05 (hooks) | 5 | All Covered | HOOK-02/HOOK-03 gate the URL reminder on `tack find` (already-tracked URLs stay silent; untracked ones nudge to create the mapping), shared in `scripts/lib-url.sh`; HOOK-04 records the session route-level when a route resolves; HOOK-05 permits the hook's deterministic reads (`tack find`) and the route-level session write while keeping URL→tack mapping with the agent |
 | REPO-01..07 (repo db) | 7 | All Covered | `~/.tack/repos.yaml` repo database (`src/repos.ts`): REPO-02 remote normalization, REPO-06 capture from deliverable/link URLs, REPO-07 capture from `init`/`pin` cwd origin; tests in `src/repos.test.ts`, `src/cli.test.ts` |
-| FUT-01..05 (future) | 5 | Deferred | Continuous git replication of `~/.tack/` — auto-commit after every write, push to a remote. Distinct from the shipped `export`/`import` (CLI-49/CLI-50), which is a deliberate one-shot JSON archive: FUT is durability and history, export/import is portability. Out of scope for v1 |
 
 ## Audit history
 
+### 2026-08-04 — Category rename + FUT dropped
+
++0 IDs, no behavior change. `RTE` → `ROUTE` and `STG` → `STORE` across the spec,
+this file, `CHANGELOG.md`, and code comments/tests — numeric parts unchanged, so
+`RTE-11` is now `ROUTE-11`. The 2026-07-08 entry below keeps its original
+prefixes: it records that rename as an event.
+
+`FUT-01..05` (continuous git replication of `~/.tack/`) removed from the spec as
+out of scope for 1.0 rather than carried as deferred; git history holds it if it
+returns. The count is unaffected — FUT was never in the normative total — but the
+spec no longer declares a deferred set, and the "no server, sync, or cloud"
+anti-requirement drops its pointer to `FUT-01`, now stating the invariant it was
+really making: core operations never require network access.
+
 ### 2026-08-04 — Coverage refresh (spec-status)
 
-+2 IDs (STG-07, STG-08), coverage 132 → 134, both Covered. STG-08 was Partial
++2 IDs (STORE-07, STORE-08), coverage 132 → 134, both Covered. STORE-08 was Partial
 mid-pass — `mergeRoutes` accepted a destination slug and `--group` without the
 boundary check — and is Covered as of the same changeset. CLI-04, CLI-15, and
 CLI-51 reworded without new IDs.
@@ -45,7 +58,7 @@ CLI-51 reworded without new IDs.
 ### 2026-08-01 — Coverage refresh (spec-status)
 
 +3 IDs (CLI-53, CLI-54, CLI-54a — `tack title` / `tack describe`, issue #31), all
-Covered; RTE-04 gained the `title`/`description` fields, CLI-14 the title in the
+Covered; ROUTE-04 gained the `title`/`description` fields, CLI-14 the title in the
 `tack list` text output, and CLI-52c the merge carry-over, none of which add an
 ID. The pass also found CLI-14's added rationale crediting the wrong code path
 for the title reaching `tack list --json` — reworded in the spec rather than
@@ -82,8 +95,8 @@ shipping code (the user's "source wins" call) plus one skill completion:
   removing the highest-numbered tack frees its id for the next `tack add`. The
   non-reuse language was struck from all three; they now state the id is
   reusable when it was the highest-numbered. No code change.
-- **RTE-06 ⇄ CLI-50.** RTE-06's "always bump `updated_at` on write" contradicted
-  `import --replace`'s verbatim restore (`writeRoute`, `src/route.ts`). RTE-06
+- **ROUTE-06 ⇄ CLI-50.** ROUTE-06's "always bump `updated_at` on write" contradicted
+  `import --replace`'s verbatim restore (`writeRoute`, `src/route.ts`). ROUTE-06
   gained a verbatim-restore exception.
 - **CLI-51 (`tack group`) drift → spec.** The shipping `tack group <slug>
   [<group>] [--clear]` show/set/clear-group command had no requirement; added as
@@ -180,9 +193,9 @@ being silently ignored by manually-parsed ones. No new ID; count holds at 104.
 
 ### 2026-06-15 — 0.18.0 (session→tack link)
 
-+2 IDs (RTE-11, AGT-11). **RTE-11** adds the optional `tacks` array to each session
++2 IDs (ROUTE-11, AGT-11). **ROUTE-11** adds the optional `tacks` array to each session
 entry — the bare route-scoped tack IDs a session is driving, in touch order
-(last = current focus). This narrows the existing session→route record (RTE-09)
+(last = current focus). This narrows the existing session→route record (ROUTE-09)
 to the specific tack(s) a session works, so a fleet view keyed on the Claude
 session id can resolve which tack a live session is on. **CLI-17** gains
 `--tack <tack-id>`, which appends the tack to the session entry (move-to-end on
@@ -217,7 +230,7 @@ group-scoped stderr errors for malformed `status set` / `todo` / `link` /
 ### 2026-06-02 — Coverage refresh (spec-status)
 
 +3 IDs (CLI-38 help/usage semantics, CLI-39/CLI-40 pins list + prune), all
-Covered; STG-06 storage relocated to `~/.tack/pins.yaml`; inventory recounted
+Covered; STORE-06 storage relocated to `~/.tack/pins.yaml`; inventory recounted
 to 99 normative by including the lettered decompositions (CLI-19a, CLI-21a..d,
 CLI-36a..d) as individual requirements — prior audits held the headline at 87
 by counting decompositions as part of their parent.
@@ -227,7 +240,7 @@ by counting decompositions as part of their parent.
 Reconciled STATUS.md against the current spec inventory (87 normative + 5
 deferred). Rebuilt the category table to include requirements added since the
 prior audit: the HOOK category (HOOK-01..05), CLI-30..36, CLI-17/CLI-18, CLI-19a,
-AGT-10, STG-06, and RTE-09/RTE-10.
+AGT-10, STORE-06, and ROUTE-09/ROUTE-10.
 
 Took the spec-alignment direction on the two gaps and brought both to
 **Covered** without touching code:
@@ -310,8 +323,8 @@ swallowed bad input).
     file's internal `slug` matches its filename. A hand-edited mismatch
     will load successfully and later save to the filename, silently
     renaming.
-  - EARS conformance polish for the "list of fields" requirements (RTE-03,
-    RTE-04, RTE-09, RTE-10, TACK-01, TACK-02, TODO-02, DEL-02, LINK-01). These remain
+  - EARS conformance polish for the "list of fields" requirements (ROUTE-03,
+    ROUTE-04, ROUTE-09, ROUTE-10, TACK-01, TACK-02, TODO-02, DEL-02, LINK-01). These remain
     acceptable Ubiquitous form. (TODO-01 reworded to shall form and CLI-21
     decomposed into sub-requirements on 2026-05-31.)
 

--- a/dist/display.test.js
+++ b/dist/display.test.js
@@ -82,7 +82,7 @@ describe("formatRoute", () => {
         const out = formatRoute(route);
         assert.ok(out.includes("[>] t1: Build it"));
     });
-    it("shows the title alongside the slug, not in place of it (RTE-04)", () => {
+    it("shows the title alongside the slug, not in place of it (ROUTE-04)", () => {
         const route = {
             id: "uuid",
             slug: "auth-rewrite",

--- a/dist/route.js
+++ b/dist/route.js
@@ -867,7 +867,7 @@ export function mergeRoutes(newSlug, srcSlugs, opts = {}) {
         throw new Error("merge-routes requires at least one source route");
     }
     // The destination is created from these arguments, so they get the same
-    // boundary check as init's ([STG-08]) rather than reaching save().
+    // boundary check as init's ([STORE-08]) rather than reaching save().
     assertValidSlug(newSlug);
     if (opts.group)
         assertValidSlug(opts.group, "group");

--- a/dist/route.test.js
+++ b/dist/route.test.js
@@ -1000,13 +1000,13 @@ describe("mergeRoutes", () => {
         data.created_at = createdAt;
         writeFileSync(path, yaml.stringify(data), "utf-8");
     }
-    it("rejects a non-conforming destination slug at the boundary (STG-08)", () => {
+    it("rejects a non-conforming destination slug at the boundary (STORE-08)", () => {
         route.init("mr-src");
         assert.throws(() => route.mergeRoutes("MergedRoute", ["mr-src"]), /Invalid slug: MergedRoute/);
         // The sources survive a refused merge.
         assert.equal(route.load("mr-src").slug, "mr-src");
     });
-    it("rejects a non-conforming --group at the boundary (STG-08)", () => {
+    it("rejects a non-conforming --group at the boundary (STORE-08)", () => {
         route.init("mr-src2");
         assert.throws(() => route.mergeRoutes("merged-ok", ["mr-src2"], { group: "Not A Group" }), /Invalid group: Not A Group/);
     });

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -74,19 +74,19 @@ Repo database (1 YAML file, ~/.tack/repos.yaml)
 
 ### RTE — Route Schema
 
-**[RTE-01]** The route schema shall use YAML as the on-disk format.
+**[ROUTE-01]** The route schema shall use YAML as the on-disk format.
 
-**[RTE-02]** Each route shall be stored as a single file at
+**[ROUTE-02]** Each route shall be stored as a single file at
 `~/.tack/routes/<slug>.yaml`.
 
-**[RTE-03]** Each route shall contain the following required fields:
+**[ROUTE-03]** Each route shall contain the following required fields:
 - `id` (string) — a v4 UUID, generated once at creation time
 - `slug` (string) — unique identifier, lowercase, hyphenated
 - `created_at` (string) — ISO 8601 timestamp
 - `updated_at` (string) — ISO 8601 timestamp
 - `tacks` (array) — list of tack objects
 
-**[RTE-04]** Each route shall contain the following optional fields:
+**[ROUTE-04]** Each route shall contain the following optional fields:
 - `group` (string) — a grouping slug for associating related routes. Multiple
   routes may share the same group. Uses the same format as `slug` (lowercase,
   hyphenated). The field is purely organizational — the CLI does not enforce or
@@ -104,35 +104,35 @@ Repo database (1 YAML file, ~/.tack/repos.yaml)
   the moment a tack lands. The CLI stores and prints the markdown verbatim; it
   does not render or interpret it.
 
-**[RTE-05]** The `slug` field shall be unique across all route files in
+**[ROUTE-05]** The `slug` field shall be unique across all route files in
 `~/.tack/routes/`. When a slug matches an existing filename, the operation
 shall fail with an error.
 
-**[RTE-06]** The `updated_at` field shall be set to the current time whenever
+**[ROUTE-06]** The `updated_at` field shall be set to the current time whenever
 the route file is written, except when `tack import --replace` ([CLI-50])
 restores a route verbatim, which preserves the archived timestamp.
 
-**[RTE-07]** A route shall be valid with an empty `tacks` array.
+**[ROUTE-07]** A route shall be valid with an empty `tacks` array.
 
-**[RTE-08]** The `id` field shall be immutable after creation. It shall not
+**[ROUTE-08]** The `id` field shall be immutable after creation. It shall not
 change when the route is updated.
 
-**[RTE-09]** Each route shall contain the following optional field:
+**[ROUTE-09]** Each route shall contain the following optional field:
 - `sessions` (array) — Claude Code session references that touched this route
 
-**[RTE-10]** Each session entry shall contain the following required fields:
+**[ROUTE-10]** Each session entry shall contain the following required fields:
 - `id` (string) — the Claude Code session identifier
 - `started_at` (string) — ISO 8601 timestamp when the session first touched
   this route
 
-**[RTE-11]** Each session entry shall contain the following optional field:
+**[ROUTE-11]** Each session entry shall contain the following optional field:
 - `tacks` (array of strings) — IDs of tacks *within this route* that the
   session is driving, in touch order. The last entry is the session's current
   focus. Because the array lives inside the route file, the IDs are bare
   route-scoped `t<N>` values; a cross-route consumer (e.g. a fleet view that
   reads every route) addresses them as `<slug>/<tack-id>` per [CLI-21a]. This
   is the session→tack link: `sessions[]` already records session→route per
-  [RTE-09], and this field narrows it to the specific tack(s) a session is
+  [ROUTE-09], and this field narrows it to the specific tack(s) a session is
   working, so a reader keyed on the Claude session id can resolve which tack a
   live session is driving — not just which route.
 
@@ -253,35 +253,35 @@ route files may not exist locally).
 
 ### STG — Storage
 
-**[STG-01]** Route files shall be stored in `~/.tack/routes/`.
+**[STORE-01]** Route files shall be stored in `~/.tack/routes/`.
 
-**[STG-02]** The storage directory shall be created automatically on first use
+**[STORE-02]** The storage directory shall be created automatically on first use
 if it does not exist.
 
-**[STG-03]** Route filenames shall match the pattern `<slug>.yaml`.
+**[STORE-03]** Route filenames shall match the pattern `<slug>.yaml`.
 
-**[STG-04]** The JSON Schema at `schema/route.schema.json` shall be the
+**[STORE-04]** The JSON Schema at `schema/route.schema.json` shall be the
 canonical validation source for route files.
 
-**[STG-05]** When reading a route file, the CLI shall validate it against the
+**[STORE-05]** When reading a route file, the CLI shall validate it against the
 JSON Schema. If validation fails, the CLI shall report the errors and exit
 without modifying the file.
 
-**[STG-07]** When reading a route file, the CLI shall require the file's
-internal `slug` to equal its filename stem (per [STG-03]) and shall otherwise
+**[STORE-07]** When reading a route file, the CLI shall require the file's
+internal `slug` to equal its filename stem (per [STORE-03]) and shall otherwise
 report the disagreement — naming both the filename and the declared slug — and
 exit without modifying the file. Writes resolve their path from the route's
 `slug`, so a file loaded under a different name would be written back under the
 declared one on the next mutation, renaming the route silently.
 
-**[STG-08]** Where a command accepts a slug from the caller — a route slug
+**[STORE-08]** Where a command accepts a slug from the caller — a route slug
 ([CLI-02], [CLI-35], [CLI-52]) or a group slug ([CLI-02], [CLI-51], [CLI-52])
 — the CLI shall check
 it against the slug pattern at the command boundary and report a message naming
 the rule. A route named in the command shall be resolved before its group
 argument is checked, so a missing route is reported as such.
 
-**[STG-06]** Pins shall be stored in a single YAML file at `~/.tack/pins.yaml`,
+**[STORE-06]** Pins shall be stored in a single YAML file at `~/.tack/pins.yaml`,
 a map keyed by absolute working-directory path. Each entry has the following
 fields:
 - `slug` (string, required) — the pinned route's slug
@@ -306,8 +306,8 @@ UUID as `id`, an empty `tacks` array, and `created_at`/`updated_at` set to
 the current time. When `--group` is passed, the route's `group` shall be set
 to the given slug. When the `CLAUDE_CODE_SESSION_ID` environment variable is
 set (the CLI is running inside a Claude Code session), the CLI shall also
-record that session on the route per [RTE-09] — route-level, without binding a
-tack ([RTE-11] binding is reserved for [CLI-07] / [CLI-17], which know the tack).
+record that session on the route per [ROUTE-09] — route-level, without binding a
+tack ([ROUTE-11] binding is reserved for [CLI-07] / [CLI-17], which know the tack).
 Creating a route in a session is a declaration that the session is working it,
 so a fleet reader keyed on the session id attributes the session to the route
 with no separate `tack session` call. Outside a Claude session this is a no-op.
@@ -338,7 +338,7 @@ deduplicated on creation against the deliverable and one another, consistent
 with [CLI-13]. The CLI shall
 reject unknown flags with a usage error rather than silently ignoring them.
 When the `CLAUDE_CODE_SESSION_ID` environment variable is set, the CLI shall
-also record that session on the route per [RTE-09], route-level (as [CLI-02]
+also record that session on the route per [ROUTE-09], route-level (as [CLI-02]
 does for `tack init`).
 
 **[CLI-05]** `tack done <slug> <tack-id> [--date <ts>]` — When invoked, the CLI
@@ -367,7 +367,7 @@ error message shall guide the user to either drop the edge with
 to bypass the guard with [CLI-34] (`tack status set`) when the inconsistent
 state is intentional. When the `CLAUDE_CODE_SESSION_ID` environment variable
 is set (the CLI is running inside a Claude Code session), the CLI shall also
-bind that session to the started tack per [RTE-11] / [CLI-17] — starting a tack
+bind that session to the started tack per [ROUTE-11] / [CLI-17] — starting a tack
 in a session is the declaration that the session is driving it, so a fleet
 reader keyed on the Claude session id (e.g. beacon) can attribute the session
 to the tack with no separate `tack session --tack` call. Outside a Claude
@@ -417,7 +417,7 @@ the `deliverable` URL or in `links`), the CLI shall not add a duplicate.
 
 **[CLI-14]** `tack list` — When invoked, the CLI shall list all route files in
 `~/.tack/routes/` with their slug, number of tacks, and number of open tacks.
-Each entry shall also carry the route's `title` ([RTE-04]) when one is set, so
+Each entry shall also carry the route's `title` ([ROUTE-04]) when one is set, so
 the listing names the route as well as addressing it. The `--json` form
 ([CLI-18]) serializes the full route, so it carries `title` alongside every
 other field.
@@ -434,9 +434,9 @@ state of the affected tack or route.
 
 **[CLI-17]** `tack session <slug> <session-id> [--tack <tack-id>]` — When
 invoked, the CLI shall record the session ID in the route's `sessions` array
-per [RTE-09]. If the session ID already exists, it shall not duplicate. When
+per [ROUTE-09]. If the session ID already exists, it shall not duplicate. When
 `--tack <tack-id>` is passed, the CLI shall bind the session to that tack per
-[RTE-11]: the tack ID is appended to the session entry's `tacks` array (bare
+[ROUTE-11]: the tack ID is appended to the session entry's `tacks` array (bare
 `<N>` is normalized to `t<N>` per [TACK-08]). A tack already present in the
 array is moved to the end rather than duplicated, so the last entry is always
 the session's current focus and a pivot back to an earlier tack makes it
@@ -555,7 +555,7 @@ plugin root) and exit zero.
 
 **[CLI-30]** `tack pin <slug>` — When invoked, the CLI shall record the given
 slug as the active route for the current working directory in
-`~/.tack/pins.yaml` per [STG-06]. The CLI shall fail if no route file exists
+`~/.tack/pins.yaml` per [STORE-06]. The CLI shall fail if no route file exists
 for the given slug. When invoked without arguments (`tack pin`), the CLI
 shall display the current cwd's pin and exit zero if one exists, or report
 that no pin is set and exit non-zero.
@@ -587,7 +587,7 @@ to `pending`, or putting a tack into `blocked`).
 
 **[CLI-35]** `tack rename <old-slug> <new-slug>` — When invoked, the CLI
 shall rename the route file from `<old-slug>.yaml` to `<new-slug>.yaml` and
-update the `slug` field inside the file. The route's `id` ([RTE-08]) shall
+update the `slug` field inside the file. The route's `id` ([ROUTE-08]) shall
 be preserved. The CLI shall fail if `<new-slug>` already exists as a route,
 if `<old-slug>` does not exist, or if any other route's `depends_on`
 references `<old-slug>` (per [DEP-01]).
@@ -649,7 +649,7 @@ and exit non-zero; the unrecognized-command case shall name the offending
 command.
 
 **[CLI-39]** `tack pins [--json]` — When invoked, the CLI shall list every pin
-in `~/.tack/pins.yaml` ([STG-06]) with its directory, slug, and `pinned_at`
+in `~/.tack/pins.yaml` ([STORE-06]) with its directory, slug, and `pinned_at`
 timestamp, flagging entries whose route no longer exists (dangling) and
 entries whose route has no open tacks (idle). With `--json`, the CLI shall
 emit the structured pin list including the computed flags. The command shall
@@ -732,9 +732,9 @@ every `old id → new id` reassignment. `--dry-run` shall report the outcome
 without writing.
 
 **[CLI-51]** `tack group <slug> [<group>] [--clear]` — When invoked with a
-`<group>` argument, the CLI shall set the route's `group` field ([RTE-04]) to
+`<group>` argument, the CLI shall set the route's `group` field ([ROUTE-04]) to
 that slug; the value is checked against the slug pattern at the command
-boundary per [STG-08].
+boundary per [STORE-08].
 When `--clear` is passed, the CLI shall remove the `group` field. When invoked
 with neither, the CLI shall report the route's current group — printing it and
 exiting zero if a group is set, or reporting that none is set and exiting
@@ -754,7 +754,7 @@ metadata — `summary`, `status`, `done_at`, `deliverable`, `links`, `before`,
 `after` — and route-local `depends_on` (remapped to the new IDs) shall be
 preserved.
 
-**[CLI-52b]** Session records ([RTE-09]) from every source shall carry over to
+**[CLI-52b]** Session records ([ROUTE-09]) from every source shall carry over to
 the new route with their tack references remapped to the new IDs; a session
 recorded on more than one source shall be unified into a single entry taking the
 earliest `started_at`. A session tack reference with no surviving tack (which
@@ -764,7 +764,7 @@ shall be dropped rather than fail the merge.
 **[CLI-52c]** The new route's `created_at` shall default to the earliest source
 route's `created_at`, or the `--created-at <date>` value when given. The new
 route's group shall be the `--group <slug>` value, or the first source route's
-group otherwise. The `title` ([RTE-04]) shall be the first source route's title.
+group otherwise. The `title` ([ROUTE-04]) shall be the first source route's title.
 Every source `description` shall carry over, joined in source order by a
 markdown horizontal rule, since the merge deletes the source files and a body
 left behind would be unrecoverable.
@@ -775,7 +775,7 @@ dangling the reference, unless `--break-deps` is passed, which repoints those
 references at `<new-slug>`.
 
 **[CLI-53]** `tack title <slug> [<text>] [--clear]` — When invoked with a
-`<text>` argument, the CLI shall set the route's `title` field ([RTE-04]) to
+`<text>` argument, the CLI shall set the route's `title` field ([ROUTE-04]) to
 that text. When `--clear` is passed, the CLI shall remove the field. When
 invoked with neither, the CLI shall report the route's current title — printing
 it and exiting zero if one is set, or reporting that none is set and exiting
@@ -783,7 +783,7 @@ non-zero, mirroring `tack group` ([CLI-51]).
 
 **[CLI-54]** `tack describe <slug> [<text>] [--file <path>] [--clear]` — When
 invoked, the CLI shall set, clear, or report the route's `description` field
-([RTE-04]) following the same three-way shape as [CLI-53].
+([ROUTE-04]) following the same three-way shape as [CLI-53].
 
 **[CLI-54a]** A description is markdown and therefore multi-line, so the CLI
 shall accept the body from a file with `--file <path>`, or from standard input
@@ -814,7 +814,7 @@ to build context about current work.
 for the current working directory by running the following resolution
 procedure in order, stopping at the first confident match:
 
-1. **Pin** — Run `tack pin` (no slug) to read the cwd's pin per [STG-06]. If
+1. **Pin** — Run `tack pin` (no slug) to read the cwd's pin per [STORE-06]. If
    present and the referenced route exists with at least one open tack, the
    pinned route is active.
 2. **URL match** — When a PR/MR/issue URL is in scope (recently emitted by
@@ -853,11 +853,11 @@ about the same work item in the same session.
 pending `after` todo items per [TACK-04] before moving on.
 
 **[AGT-09]** When the agent begins operating on a route, it shall record the
-current Claude Code session ID in the route's `sessions` array per [RTE-09].
+current Claude Code session ID in the route's `sessions` array per [ROUTE-09].
 If the session ID already exists, it shall not duplicate. When the agent has
 resolved which tack the session is working — a tack matched per [AGT-11], the
 single open tack, or one the agent created for this session — it shall pass
-`--tack <tack-id>` to bind the session to that tack per [RTE-11], and re-bind
+`--tack <tack-id>` to bind the session to that tack per [ROUTE-11], and re-bind
 when the session's focus shifts to a different tack.
 
 **[AGT-11]** The agent shall establish the session→tack link as early as it
@@ -921,7 +921,7 @@ through a Bash tool call.
 the route for the current cwd by running [AGT-03] step 1 (pin for cwd, via
 `tack pin`) and step 3 (branch-slug route) — existence-only, without verifying
 the route's open-tack state and without prompting the user. When a route
-resolves, the hook shall record the current session on it per [RTE-09]
+resolves, the hook shall record the current session on it per [ROUTE-09]
 (route-level, no tack binding), so session→route attribution does not depend on
 the agent remembering to run `tack session`. When neither resolves, the hook
 shall emit a one-line nudge suggesting the user invoke the tack skill to
@@ -966,7 +966,7 @@ and SSH forms of one remote resolve to a single entry (e.g.
 **[REPO-04]** The `~/.tack/repos.yaml` file and the `~/.tack/` directory shall be
 created automatically on first write if they do not exist.
 
-**[REPO-05]** The repo database is internal derived state, like pins ([STG-06]):
+**[REPO-05]** The repo database is internal derived state, like pins ([STORE-06]):
 tack is its sole writer, so — unlike the route schema, which is the product —
 it is not governed by a published JSON Schema. A missing file shall be treated
 as an empty database.
@@ -985,29 +985,6 @@ is present, the CLI shall record nothing and shall not error.
 
 ---
 
-## Future Requirements
-
-**[FUT-01]** (→ BK) Where backup is enabled, the `~/.tack/` directory shall be
-a git repository. Route file changes shall be the only tracked content.
-
-**[FUT-02]** (→ BK) `tack backup init [<remote-url>]` — When invoked, the CLI
-shall initialize a git repository at `~/.tack/` if one does not exist. When a
-remote URL is provided, it shall be configured as the `origin` remote.
-
-**[FUT-03]** (→ BK) `tack backup status` — When invoked, the CLI shall display
-whether backup is enabled, the configured remote (if any), the last commit
-timestamp, and whether there are uncommitted changes.
-
-**[FUT-04]** (→ BK) Where backup is enabled, the CLI shall commit all route
-file changes after every write operation. The commit message shall include the
-command that triggered the write (e.g., "tack done api-auth t2").
-
-**[FUT-05]** (→ BK) Where a remote is configured, the CLI shall push to the
-remote after each commit. If the push fails, the CLI shall warn but not block
-the operation.
-
----
-
 ## Anti-Requirements
 
 The following are explicitly out of scope:
@@ -1018,7 +995,7 @@ The following are explicitly out of scope:
 - **No enforced workflows.** No prescribed state machines beyond the status
   enum. Users can move between statuses freely (except where dependencies
   constrain transitions per [DEP-03]).
-- **No server, sync, or cloud.** Local files only. (Backup to a git remote
-  per [FUT-01] is a planned exception — core operations never require network.)
+- **No server, sync, or cloud.** Local files only; core operations never
+  require network access.
 - **No cross-route dependency enforcement.** Route-level `depends_on` is
   informational only per [DEP-04].

--- a/src/display.test.ts
+++ b/src/display.test.ts
@@ -94,7 +94,7 @@ describe("formatRoute", () => {
     assert.ok(out.includes("[>] t1: Build it"));
   });
 
-  it("shows the title alongside the slug, not in place of it (RTE-04)", () => {
+  it("shows the title alongside the slug, not in place of it (ROUTE-04)", () => {
     const route: Route = {
       id: "uuid",
       slug: "auth-rewrite",

--- a/src/route.test.ts
+++ b/src/route.test.ts
@@ -1235,14 +1235,14 @@ describe("mergeRoutes", () => {
     writeFileSync(path, yaml.stringify(data), "utf-8");
   }
 
-  it("rejects a non-conforming destination slug at the boundary (STG-08)", () => {
+  it("rejects a non-conforming destination slug at the boundary (STORE-08)", () => {
     route.init("mr-src");
     assert.throws(() => route.mergeRoutes("MergedRoute", ["mr-src"]), /Invalid slug: MergedRoute/);
     // The sources survive a refused merge.
     assert.equal(route.load("mr-src").slug, "mr-src");
   });
 
-  it("rejects a non-conforming --group at the boundary (STG-08)", () => {
+  it("rejects a non-conforming --group at the boundary (STORE-08)", () => {
     route.init("mr-src2");
     assert.throws(
       () => route.mergeRoutes("merged-ok", ["mr-src2"], { group: "Not A Group" }),

--- a/src/route.ts
+++ b/src/route.ts
@@ -1079,7 +1079,7 @@ export function mergeRoutes(
     throw new Error("merge-routes requires at least one source route");
   }
   // The destination is created from these arguments, so they get the same
-  // boundary check as init's ([STG-08]) rather than reaching save().
+  // boundary check as init's ([STORE-08]) rather than reaching save().
   assertValidSlug(newSlug);
   if (opts.group) assertValidSlug(opts.group, "group");
   const srcSet = new Set<string>();


### PR DESCRIPTION
## Context

Depends on #36 — that must merge first. GitHub won't enforce it: this branch is stacked on `pre-1-0-correctness`, so it renames `STG-07`/`STG-08`, which only exist once #36 lands. Until then the diff here shows both commits.

tack's spec identifies requirements by a category prefix plus a number (`RTE-11`, `STG-06`). Two of those prefixes needed a reader to already know the abbreviation — reviewing the coverage ledger produced a literal *"what does STG mean?"*, because the expansion lives only in the spec's own category table and the ledger just prints the prefix. `ROUTE` and `STORE` carry it without the legend.

Also drops the `FUT` set: five requirements specifying continuous git replication of `~/.tack/` that nobody is building. No behavior change anywhere in this PR.

## Review guide

**The renames are mechanical** — `RTE` → `ROUTE`, `STG` → `STORE`, numeric parts untouched, so `RTE-11` is now `ROUTE-11` and no requirement moves. Landing points if you want to spot-check the shape: the spec's [category table](https://github.com/chris-peterson/tack/pull/37/changes#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0R63) and the ledger's [ROUTE](https://github.com/chris-peterson/tack/pull/37/changes#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR23) / [STORE](https://github.com/chris-peterson/tack/pull/37/changes#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR29) rows.

**The one line deliberately left stale** — `STATUS.md`'s 2026-07-08 audit entry records the *previous* rename as an event (`RT→RTE, … ST→STG`). Sweeping it would make the history assert a rename that never happened, so it keeps its original prefixes. `CHANGELOG.md`'s ID citations *were* swept, on the opposite reasoning: they point at requirements that still exist under a new label, so sweeping keeps the pointer resolvable.

**FUT removal has one non-mechanical consequence** — [`spec/v1/SPEC.md:998`](https://github.com/chris-peterson/tack/pull/37/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R998). The "no server, sync, or cloud" anti-requirement carried *"(Backup to a git remote per [FUT-01] is a planned exception)"*, which now points at a deleted ID. This is the line worth your judgment — see below.

**Counts** — the normative total stays 134; FUT was always excluded from it. What changes is that the spec no longer declares a deferred set, so the ledger's coverage line drops its "plus 5 deferred" clause. Verified after each edit that the header count, the sum of the per-category rows, and the spec's declared-ID inventory all agree.

## Approach & trade-offs

**Why remove FUT rather than leave it deferred.** A spec that publishes a stable major shouldn't declare a feature set nobody is building, and this one read as already-shipped besides: `export`/`import` (`CLI-49`/`CLI-50`) shares the word "backup" while solving portability, where FUT specified durability and history. That collision is what prompted the question. Git history holds the text if it returns.

**The anti-requirement rewording is the judgment call.** Deleting the parenthetical outright would leave a flat *"no server, sync, or cloud, local files only"* — freezing an absolute into 1.0 that any future opt-in backup would contradict. It now states the invariant the exception was really protecting: *core operations never require network access*. That stays true whether or not an opt-in networked feature is ever added. If you'd rather 1.0 commit to the absolute, that's a one-line change.
