### PR TITLE
gitlab work items

### DIFF
--- a/dist/repos.js
+++ b/dist/repos.js
@@ -37,7 +37,12 @@ export function repoKeyFromForgeUrl(url) {
     const gh = url.match(/^https:\/\/(github\.com)\/([^/]+)\/([^/]+)\/(?:pull|issues|commit)\//i);
     if (gh)
         return `${gh[1]}/${gh[2]}/${gh[3].replace(/\.git$/, "")}`;
-    const gl = url.match(/^https:\/\/(gitlab\.[^/]+)\/(.+?)\/-\/(?:merge_requests|issues|commit)\//i);
+    // `work_items` is the same project-scoped issue as `issues`, so it yields the
+    // same repo key. Epics and milestones are deliberately absent: both can be
+    // group-scoped (`/groups/<group>/-/…`), where the path segment that would be
+    // captured is a group rather than a repo — recording that as a repo would put
+    // a non-repo entry in the database.
+    const gl = url.match(/^https:\/\/(gitlab\.[^/]+)\/(.+?)\/-\/(?:merge_requests|issues|work_items|commit)\//i);
     if (gl)
         return `${gl[1]}/${gl[2].replace(/\.git$/, "")}`;
     return null;

--- a/dist/repos.test.js
+++ b/dist/repos.test.js
@@ -164,3 +164,16 @@ describe("removeRepo (CLI-46)", () => {
         assert.throws(() => repos.removeRepo("alpha"), /matches 2 repos/);
     });
 });
+describe("repoKeyFromForgeUrl and the GitLab work-item paths (issue #33)", () => {
+    it("derives the same repo key from work_items as from issues", () => {
+        assert.equal(repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/work_items/9"), repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/issues/9"));
+    });
+    // Both can be group-scoped, where the captured segment is a group rather than
+    // a repo; recording that would put a non-repo entry in the database.
+    it("derives no repo key from a group epic", () => {
+        assert.equal(repos.repoKeyFromForgeUrl("https://gitlab.example.com/groups/mygroup/-/epics/5"), null);
+    });
+    it("derives no repo key from a milestone", () => {
+        assert.equal(repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/milestones/3"), null);
+    });
+});

--- a/dist/route.d.ts
+++ b/dist/route.d.ts
@@ -86,6 +86,7 @@ export interface FindMatch {
     label: string;
     url: string;
 }
+export declare function canonicalizeUrl(url: string): string;
 export declare function find(url: string): FindMatch[];
 export declare function findByRepoKey(key: string): FindMatch[];
 export declare function findCollisions(url: string, exclude: {

--- a/dist/route.js
+++ b/dist/route.js
@@ -503,9 +503,20 @@ function parseChangeRefUrl(url) {
     if (ghCommit) {
         return { repo: ghCommit[1], ref: ghCommit[2].slice(0, 7), kind: "commit" };
     }
-    const gl = url.match(/^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/(merge_requests|issues)\/(\d+)/);
+    // `work_items` is GitLab's newer path for the same issue `/-/issues/<n>`
+    // serves, so it derives the same ref. Epics live under /groups/<group>/-/,
+    // which puts the group where a project name sits in the other forms — the
+    // captured name is the group, which is what an epic belongs to.
+    const gl = url.match(/^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/(merge_requests|issues|work_items|epics|milestones)\/(\d+)/);
     if (gl) {
-        return { repo: gl[1], ref: gl[3], kind: gl[2] === "merge_requests" ? "mr" : "issue" };
+        const kinds = {
+            merge_requests: "mr",
+            issues: "issue",
+            work_items: "issue",
+            epics: "epic",
+            milestones: "milestone",
+        };
+        return { repo: gl[1], ref: gl[3], kind: kinds[gl[2]] };
     }
     const glCommit = url.match(/^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/commit\/([0-9a-f]+)/i);
     if (glCommit) {
@@ -519,11 +530,14 @@ function isPrOrMrUrl(url) {
 }
 // Canonical forge notation attaches a kind-specific sigil to the repo:
 // `repo#42` for a PR/issue, `repo!99` for an MR, `repo@<sha7>` for a commit.
+// Epics and milestones reuse GitLab's own reference syntax, `&` and `%`.
 const CHANGE_REF_SIGIL = {
     pr: "#",
     issue: "#",
     mr: "!",
     commit: "@",
+    epic: "&",
+    milestone: "%",
 };
 export function deriveDeliverableLabel(url) {
     const ref = parseChangeRefUrl(url);
@@ -666,8 +680,16 @@ function findBy(accepts) {
     }
     return matches;
 }
+// GitLab serves one issue from two paths, so two recordings of the same issue
+// are not string-equal. Canonicalize the newer form onto the older one for
+// comparison only — stored URLs stay exactly as the caller gave them, since
+// that is the link the user actually followed.
+export function canonicalizeUrl(url) {
+    return url.replace(/^(https:\/\/gitlab\.[^/]*\/.*?\/-\/)work_items(\/\d+)/, "$1issues$2");
+}
 export function find(url) {
-    return findBy((u) => u === url);
+    const target = canonicalizeUrl(url);
+    return findBy((u) => canonicalizeUrl(u) === target);
 }
 // CLI-23a: return every tack whose deliverable or link URL belongs to the given
 // repo key, computed via the forge-URL recognition rules ([CLI-37]). Powers

--- a/dist/route.test.js
+++ b/dist/route.test.js
@@ -417,6 +417,15 @@ describe("deriveDeliverableLabel", () => {
     it("parses GitLab issue URLs", () => {
         assert.equal(route.deriveDeliverableLabel("https://gitlab.example.com/group/repo/-/issues/12"), "repo#12");
     });
+    it("parses GitLab work_items URLs identically to issues (issue #33)", () => {
+        assert.equal(route.deriveDeliverableLabel("https://gitlab.example.com/group/repo/-/work_items/12"), "repo#12");
+    });
+    it("parses GitLab epic URLs with GitLab's & reference sigil", () => {
+        assert.equal(route.deriveDeliverableLabel("https://gitlab.example.com/groups/mygroup/-/epics/5"), "mygroup&5");
+    });
+    it("parses GitLab milestone URLs with GitLab's % reference sigil", () => {
+        assert.equal(route.deriveDeliverableLabel("https://gitlab.example.com/group/repo/-/milestones/3"), "repo%3");
+    });
     it("parses GitHub commit URLs to repo@sha7", () => {
         assert.equal(route.deriveDeliverableLabel("https://github.com/owner/repo/commit/44cf536abc1234567890"), "repo@44cf536");
     });
@@ -1465,5 +1474,43 @@ describe("filename and internal slug must agree", () => {
         // real-slug.yaml, leaving two files and a route the user can't address.
         assert.throws(() => route.addTack("other-name", "work"));
         assert.ok(!existsSync(join(routes, "real-slug.yaml")));
+    });
+});
+describe("work_items and issues are one URL when matching (issue #33)", () => {
+    it("find matches a work_items URL against a stored issues URL", () => {
+        route.init("wi-find");
+        route.addTack("wi-find", "work");
+        route.addLink("wi-find", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+        const hits = route.find("https://gitlab.example.com/g/p/-/work_items/9");
+        assert.equal(hits.length, 1);
+        assert.equal(hits[0].slug, "wi-find");
+    });
+    it("find matches an issues URL against a stored work_items URL", () => {
+        route.init("wi-find-rev");
+        route.addTack("wi-find-rev", "work");
+        route.addLink("wi-find-rev", "t1", "issue", "https://gitlab.example.com/g/p/-/work_items/9");
+        assert.equal(route.find("https://gitlab.example.com/g/p/-/issues/9").length, 1);
+    });
+    it("does not collapse different issue numbers", () => {
+        route.init("wi-distinct");
+        route.addTack("wi-distinct", "work");
+        route.addLink("wi-distinct", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+        assert.equal(route.find("https://gitlab.example.com/g/p/-/work_items/10").length, 0);
+    });
+    it("does not collapse across projects", () => {
+        route.init("wi-proj");
+        route.addTack("wi-proj", "work");
+        route.addLink("wi-proj", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+        assert.equal(route.find("https://gitlab.example.com/g/other/-/work_items/9").length, 0);
+    });
+    it("stores the URL exactly as given", () => {
+        route.init("wi-verbatim");
+        route.addTack("wi-verbatim", "work");
+        const url = "https://gitlab.example.com/g/p/-/work_items/9";
+        route.addLink("wi-verbatim", "t1", "issue", url);
+        assert.equal(route.load("wi-verbatim").tacks[0].links?.[0].url, url);
+    });
+    it("leaves GitHub URLs untouched", () => {
+        assert.equal(route.canonicalizeUrl("https://github.com/o/r/issues/9"), "https://github.com/o/r/issues/9");
     });
 });

--- a/plans/1.0.md
+++ b/plans/1.0.md
@@ -1,0 +1,136 @@
+# tack 1.0 — working plan
+
+Living plan for the 1.0 push. Update it as work lands; a fresh session should be
+able to read this and pick up without re-deriving anything.
+
+**Current version:** 0.29.0 · **Spec:** v1, 134/134 normative covered ·
+**Route:** `tack` (tacks t24–t28)
+
+## What 1.0 means here
+
+1.0 is a contract promise, not a feature milestone. The spec was already at 100%
+coverage when this started; what was missing was a *mechanism* behind the
+promise, and the correctness fixes a stable major would otherwise freeze in
+place.
+
+Scope was set as **freeze-only**: guardrails, correctness, and a written
+compatibility contract. Features are deferred to post-1.0 regardless of how
+small — see "Explicitly out of scope".
+
+**Cadence:** one PR at a time, stop for review after each.
+
+## Landed
+
+| Tack | Work | Deliverable |
+|---|---|---|
+| t24 | CI gates: committed `dist/`, CLI grammar snapshot, schema conformance, shellcheck, generated-artifact drift | [#35](https://github.com/chris-peterson/tack/pull/35) |
+| t25 | Four boundary defects: `--link` comma parse, `tack rm` refusal to stderr, boundary slug validation (STORE-08), filename↔slug agreement (STORE-07) | [#36](https://github.com/chris-peterson/tack/pull/36) |
+| t29 | Category rename `RTE`→`ROUTE`, `STG`→`STORE`; dropped the `FUT` deferred set | [#37](https://github.com/chris-peterson/tack/pull/37) |
+
+Test suite went 296 → 341 across these.
+
+## Remaining
+
+### t26 — GitLab `work_items` / epics / milestones (issue #33)
+
+**Code is done, committed, and pushed. No PR yet.**
+
+- Branch `gitlab-work-items`, commit `7a3df7d`, based on current `main`.
+- Next step: `/anchor:prepare-review`, then merge, then `tack done tack t26`.
+- Widens `URL_PATTERN` and `parseChangeRefUrl` for `work_items`, `epics`,
+  `milestones`; epics/milestones label as `<group>&<n>` / `<repo>%<n>` and are
+  links rather than deliverables; `find()` canonicalizes `work_items`→`issues`
+  for comparison only.
+- Spec: new CLI-37b; CLI-37, CLI-23, CLI-48 reworded.
+
+### t27 — Declare the compatibility contract
+
+The core 1.0 deliverable, and the only one still unstarted. Nothing in the repo
+currently states what a 1.0 freezes. Needs to answer, in `SPEC.md` and the
+README:
+
+- **What is frozen** — the route YAML schema, the CLI command grammar, exit
+  codes, and `--json` output shapes.
+- **What is not** — `~/.tack/pins.yaml` and `~/.tack/repos.yaml` as internal
+  derived state, hook nudge text, human-readable output formatting.
+- **What a 2.0 would mean** — which changes require a major bump.
+- **`spec/v1/cli-usage.txt`** — the grammar snapshot t24 added has no
+  requirement describing it, and it sits inside the spec directory. Settle here:
+  name it as the freeze mechanism in the contract, or give it a requirement.
+  (Raised by the `/sextant:spec-sync` pass; deliberately deferred to t27.)
+
+### t28 — Cut 1.0.0
+
+Via `/anchor:release`. Note the repo's release workflow delegates to shipyard's
+reusable workflow on `release: published`, so the version bump owner needs
+confirming before anything is hand-edited.
+
+## Open decisions (carried, unanswered)
+
+These were surfaced during the push and never settled. None blocks t26.
+
+1. **Slug minimum length.** `schema/route.schema.json` uses
+   `^[a-z0-9][a-z0-9-]*[a-z0-9]$`, which requires *two* characters — `tack init x`
+   is rejected. Predates this work (it already failed at `save()`); t25 only
+   moved the failure to the command boundary. Worth settling before the freeze:
+   loosening the rule after 1.0 is fine, tightening it is not.
+
+2. **Top-level error handler.** The CLI has none, so every `route.ts` throw
+   prints a raw Node stack trace — including ordinary conditions like
+   `tack status no-such` and "deliverable already set". Pre-existing, but it
+   undercuts STORE-08's "report a message naming the rule" and is a poor first
+   impression for a 1.0. Would change the observable output of every error path,
+   so it belongs before the freeze if it's going to happen at all.
+
+3. **`loadAll()` strictness.** t25 made `load()` refuse a filename↔slug
+   mismatch, and `loadAll()` reads every route through it — so one hand-edited
+   bad file now fails `tack list` / `tack status --all` outright. Matches the
+   fail-visibly stance in AGENTS.md; the alternative is loud-but-partial
+   listing. Left as-is pending a call.
+
+## Loose ends
+
+- **Close [#28](https://github.com/chris-peterson/tack/issues/28)** — fixed by
+  #36 (the comma-in-label parse), but the PR referenced it without a closing
+  keyword, so it is still open.
+- **[#33](https://github.com/chris-peterson/tack/issues/33)** closes when t26's
+  PR merges — again, add the closing keyword to that PR.
+- **Label the deferred issues post-1.0** —
+  [#14](https://github.com/chris-peterson/tack/issues/14),
+  [#18](https://github.com/chris-peterson/tack/issues/18),
+  [#34](https://github.com/chris-peterson/tack/issues/34), so the freeze scope
+  is visible on the forge.
+- **Refresh the ledger** — `STATUS.md` has not absorbed t26's CLI-37b.
+
+## Explicitly out of scope for 1.0
+
+Deferred as additive work that a stable major does not need to precede:
+
+- [#14](https://github.com/chris-peterson/tack/issues/14) — `--insert-before` /
+  `--insert-after` for `tack add`. Purely additive.
+- [#18](https://github.com/chris-peterson/tack/issues/18) — derived route
+  status, `created_at` floor, auto-done-on-merge. Changes what route fields
+  *mean*; the auto-done half needs forge polling. Deferring was a deliberate
+  call, so landing it later is a semantic change to document.
+- [#34](https://github.com/chris-peterson/tack/issues/34) — `tack serve`. HTTP
+  server, service units, inline assets. The time sink on the list.
+
+Filed upstream, not tack work:
+[shipyard#13](https://github.com/chris-peterson/shipyard/issues/13) — promote
+the CLI grammar snapshot to a shipyard generator with an engine-agnostic YAML
+manifest.
+
+## Mechanics a fresh session needs
+
+- **Gates** — every one has a `just` recipe and runs in CI; the table in
+  `AGENTS.md` says what each catches. `just check` only *previews* generated
+  drift (its `--dry-run` exits zero even with drift pending); `just
+  check-generated` is the gate.
+- **Grammar changes** — re-record with `just usage-snapshot` in the same commit,
+  or the snapshot test fails.
+- **`dist/` is committed and is what `bin/tack` runs.** Rebuild before
+  committing a `src/` change.
+- **Sextant skills are not model-invocable.** `/sextant:spec-status` and
+  `/sextant:spec-sync` must be typed by the user; `STATUS.md` is written from
+  their procedure and should not be hand-edited.
+- **Session binding** — `tack session tack <session-id> --tack <tack-id>`.

--- a/scripts/lib-url.sh
+++ b/scripts/lib-url.sh
@@ -3,8 +3,10 @@
 # hooks/capture-urls.sh), which source this by relative path.
 # Source this; don't execute it.
 
-# The pattern both hooks use to spot a GitHub PR/issue or GitLab MR/issue URL.
-URL_PATTERN='https://(github\.com/[^/]+/[^/]+/(pull|issues)|gitlab\.[^[:space:]]*/-/(merge_requests|issues))/[0-9]+'
+# The pattern both hooks use to spot a GitHub PR/issue or GitLab MR/issue/
+# epic/milestone URL. GitLab serves issues from both /-/issues/<n> and the newer
+# /-/work_items/<n>; both are live, so both are matched.
+URL_PATTERN='https://(github\.com/[^/]+/[^/]+/(pull|issues)|gitlab\.[^[:space:]]*/-/(merge_requests|issues|work_items|epics|milestones))/[0-9]+'
 
 # url_nudges <text> <source-label>
 #

--- a/skills/tack/SKILL.md
+++ b/skills/tack/SKILL.md
@@ -146,6 +146,16 @@ tool output or user prompts. When you see one:
      one (e.g. an unrecognized forge URL, or you want prose).
    - Other URLs (issues, docs, threads) → `tack link add <slug> <tack-id>
      "<label>" "<url>"`
+   - **Epics and milestones are links, never deliverables.** A deliverable is
+     the change request a tack produces; an epic or milestone is a container
+     the work sits inside, so several tacks can share one and none of them
+     *is* it. Labels derive as `<group>&<n>` and `<repo>%<n>`, GitLab's own
+     reference syntax.
+   - GitLab serves the same issue from `/-/issues/<n>` and `/-/work_items/<n>`.
+     Both are recognized and derive the same `<repo>#<n>` label. They are
+     stored as written, so recording one form when the other is already
+     attached leaves two links pointing at one issue — prefer whichever form
+     the route already uses.
 
    Before calling `tack deliverable`, verify the tack ID with `tack tree
    <slug>` (or read the YAML). `tack deliverable` refuses to overwrite an

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -496,9 +496,12 @@ in_progress, `[x]` done, `[!]` blocked, `[-]` dropped. Todo items shall use
 **[CLI-23]** `tack find --url <url> [--json]` — When invoked with `--url`, the
 CLI shall search all routes for tacks whose deliverable URL or link URLs match
 the given URL, and display each match as a tree: route slug, tack summary, and
-the matching deliverable or link. When `--json` is passed, the CLI shall output
-the results as JSON. If no matches are found, the CLI shall report that no tacks
-reference the given URL.
+the matching deliverable or link. Matching is exact, except that a GitLab
+`/-/work_items/<n>` URL and the `/-/issues/<n>` URL for the same project and
+number shall match each other ([CLI-37]) — one issue, two paths. Canonicalization
+applies to the comparison only; URLs are stored as given. When `--json` is
+passed, the CLI shall output the results as JSON. If no matches are found, the
+CLI shall report that no tacks reference the given URL.
 
 **[CLI-23a]** `tack find --path [<dir>] [--json]` — When invoked with `--path`,
 the CLI shall resolve the given directory (default the current working
@@ -624,11 +627,23 @@ source route.
 **[CLI-37]** The PR/MR/issue URL recognition used for deliverable
 auto-derivation and label extraction ([CLI-04], [CLI-08], [CLI-13]) shall support
 two forges: GitHub (`https://github.com/<owner>/<repo>/pull/<n>` and
-`/issues/<n>`) and GitLab (`https://gitlab.<host>/<group>/<repo>/-/merge_requests/<n>`
-and `/-/issues/<n>`). The derived label is `<repo>#<n>` for a PR or issue and
-`<repo>!<n>` for an MR. URLs from other forges are recorded verbatim as links
-or labels but are not classified as PR/MR/issue. The hook scanners ([HOOK-02],
-[HOOK-03]) recognize the same two forges.
+`/issues/<n>`) and GitLab (`https://gitlab.<host>/<group>/<repo>/-/merge_requests/<n>`,
+`/-/issues/<n>`, and `/-/work_items/<n>`). The derived label is `<repo>#<n>` for
+a PR or issue and `<repo>!<n>` for an MR. GitLab serves one issue from both
+`/-/issues/<n>` and `/-/work_items/<n>`; the CLI shall recognize both and derive
+the same label and `issue` kind from each. URLs from other forges are recorded
+verbatim as links or labels but are not classified as PR/MR/issue. The hook
+scanners ([HOOK-02], [HOOK-03]) recognize the same two forges.
+
+**[CLI-37b]** GitLab epic (`https://gitlab.<host>/groups/<group>/-/epics/<n>`)
+and milestone (`/-/milestones/<n>`) URLs shall additionally be recognized for
+label derivation ([CLI-04], [CLI-08]), producing `<group>&<n>` and `<repo>%<n>`
+respectively — GitLab's own reference syntax. Neither is a change request: they
+shall not be promoted to a deliverable on `tack done` ([CLI-05]). Both shall be
+surfaced by the hook scanners ([HOOK-02], [HOOK-03]), which nudge the agent to
+record them as links ([AGT-06]). Neither shall contribute an entry to the repo
+database ([REPO-06]): both can be group-scoped, where the path carries a group
+rather than a repo.
 
 **[CLI-37a]** Commit URLs — `https://github.com/<owner>/<repo>/commit/<sha>` and
 `https://gitlab.<host>/<group>/<repo>/-/commit/<sha>` — are additionally
@@ -705,7 +720,8 @@ re-run. It backfills the database for routes recorded before capture existed.
 **[CLI-48]** Duplicate-URL warning — When a URL is attached as a deliverable
 (`tack add --deliverable`, `tack deliverable`) or a link (`tack link add`),
 the CLI shall check whether the same URL already appears as a deliverable or
-link on any other tack (the same exact-URL match as `tack find`, [CLI-23]), and
+link on any other tack (the same match rule as `tack find`, [CLI-23], so the two
+GitLab issue paths warn against each other), and
 if so shall print a warning to stderr that names the existing route(s) and tack
 id(s) with a `warning: url already on ` prefix. The tack being mutated is
 excluded, so re-attaching a URL already present on that same tack does not

--- a/src/repos.test.ts
+++ b/src/repos.test.ts
@@ -228,3 +228,28 @@ describe("removeRepo (CLI-46)", () => {
     assert.throws(() => repos.removeRepo("alpha"), /matches 2 repos/);
   });
 });
+
+describe("repoKeyFromForgeUrl and the GitLab work-item paths (issue #33)", () => {
+  it("derives the same repo key from work_items as from issues", () => {
+    assert.equal(
+      repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/work_items/9"),
+      repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/issues/9"),
+    );
+  });
+
+  // Both can be group-scoped, where the captured segment is a group rather than
+  // a repo; recording that would put a non-repo entry in the database.
+  it("derives no repo key from a group epic", () => {
+    assert.equal(
+      repos.repoKeyFromForgeUrl("https://gitlab.example.com/groups/mygroup/-/epics/5"),
+      null,
+    );
+  });
+
+  it("derives no repo key from a milestone", () => {
+    assert.equal(
+      repos.repoKeyFromForgeUrl("https://gitlab.example.com/group/repo/-/milestones/3"),
+      null,
+    );
+  });
+});

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -60,8 +60,13 @@ export function repoKeyFromForgeUrl(url: string): string | null {
   );
   if (gh) return `${gh[1]}/${gh[2]}/${gh[3].replace(/\.git$/, "")}`;
 
+  // `work_items` is the same project-scoped issue as `issues`, so it yields the
+  // same repo key. Epics and milestones are deliberately absent: both can be
+  // group-scoped (`/groups/<group>/-/…`), where the path segment that would be
+  // captured is a group rather than a repo — recording that as a repo would put
+  // a non-repo entry in the database.
   const gl = url.match(
-    /^https:\/\/(gitlab\.[^/]+)\/(.+?)\/-\/(?:merge_requests|issues|commit)\//i,
+    /^https:\/\/(gitlab\.[^/]+)\/(.+?)\/-\/(?:merge_requests|issues|work_items|commit)\//i,
   );
   if (gl) return `${gl[1]}/${gl[2].replace(/\.git$/, "")}`;
 

--- a/src/route.test.ts
+++ b/src/route.test.ts
@@ -540,6 +540,27 @@ describe("deriveDeliverableLabel", () => {
     );
   });
 
+  it("parses GitLab work_items URLs identically to issues (issue #33)", () => {
+    assert.equal(
+      route.deriveDeliverableLabel("https://gitlab.example.com/group/repo/-/work_items/12"),
+      "repo#12",
+    );
+  });
+
+  it("parses GitLab epic URLs with GitLab's & reference sigil", () => {
+    assert.equal(
+      route.deriveDeliverableLabel("https://gitlab.example.com/groups/mygroup/-/epics/5"),
+      "mygroup&5",
+    );
+  });
+
+  it("parses GitLab milestone URLs with GitLab's % reference sigil", () => {
+    assert.equal(
+      route.deriveDeliverableLabel("https://gitlab.example.com/group/repo/-/milestones/3"),
+      "repo%3",
+    );
+  });
+
   it("parses GitHub commit URLs to repo@sha7", () => {
     assert.equal(
       route.deriveDeliverableLabel(
@@ -1825,5 +1846,57 @@ describe("filename and internal slug must agree", () => {
     // real-slug.yaml, leaving two files and a route the user can't address.
     assert.throws(() => route.addTack("other-name", "work"));
     assert.ok(!existsSync(join(routes, "real-slug.yaml")));
+  });
+});
+
+describe("work_items and issues are one URL when matching (issue #33)", () => {
+  it("find matches a work_items URL against a stored issues URL", () => {
+    route.init("wi-find");
+    route.addTack("wi-find", "work");
+    route.addLink("wi-find", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+
+    const hits = route.find("https://gitlab.example.com/g/p/-/work_items/9");
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].slug, "wi-find");
+  });
+
+  it("find matches an issues URL against a stored work_items URL", () => {
+    route.init("wi-find-rev");
+    route.addTack("wi-find-rev", "work");
+    route.addLink("wi-find-rev", "t1", "issue", "https://gitlab.example.com/g/p/-/work_items/9");
+
+    assert.equal(route.find("https://gitlab.example.com/g/p/-/issues/9").length, 1);
+  });
+
+  it("does not collapse different issue numbers", () => {
+    route.init("wi-distinct");
+    route.addTack("wi-distinct", "work");
+    route.addLink("wi-distinct", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+
+    assert.equal(route.find("https://gitlab.example.com/g/p/-/work_items/10").length, 0);
+  });
+
+  it("does not collapse across projects", () => {
+    route.init("wi-proj");
+    route.addTack("wi-proj", "work");
+    route.addLink("wi-proj", "t1", "issue", "https://gitlab.example.com/g/p/-/issues/9");
+
+    assert.equal(route.find("https://gitlab.example.com/g/other/-/work_items/9").length, 0);
+  });
+
+  it("stores the URL exactly as given", () => {
+    route.init("wi-verbatim");
+    route.addTack("wi-verbatim", "work");
+    const url = "https://gitlab.example.com/g/p/-/work_items/9";
+    route.addLink("wi-verbatim", "t1", "issue", url);
+
+    assert.equal(route.load("wi-verbatim").tacks[0].links?.[0].url, url);
+  });
+
+  it("leaves GitHub URLs untouched", () => {
+    assert.equal(
+      route.canonicalizeUrl("https://github.com/o/r/issues/9"),
+      "https://github.com/o/r/issues/9",
+    );
   });
 });

--- a/src/route.ts
+++ b/src/route.ts
@@ -602,10 +602,11 @@ export function dropTodo(slug: string, tackId: string, todoId: string): Tack {
   return tack;
 }
 
-type ChangeRefKind = "pr" | "mr" | "issue" | "commit";
+type ChangeRefKind = "pr" | "mr" | "issue" | "commit" | "epic" | "milestone";
 interface ChangeRef {
   repo: string;
-  // PR/MR/issue number, or the abbreviated (7-char) sha for a commit.
+  // PR/MR/issue/epic/milestone number, or the abbreviated (7-char) sha for a
+  // commit.
   ref: string;
   kind: ChangeRefKind;
 }
@@ -623,11 +624,22 @@ function parseChangeRefUrl(url: string): ChangeRef | null {
   if (ghCommit) {
     return { repo: ghCommit[1], ref: ghCommit[2].slice(0, 7), kind: "commit" };
   }
+  // `work_items` is GitLab's newer path for the same issue `/-/issues/<n>`
+  // serves, so it derives the same ref. Epics live under /groups/<group>/-/,
+  // which puts the group where a project name sits in the other forms — the
+  // captured name is the group, which is what an epic belongs to.
   const gl = url.match(
-    /^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/(merge_requests|issues)\/(\d+)/,
+    /^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/(merge_requests|issues|work_items|epics|milestones)\/(\d+)/,
   );
   if (gl) {
-    return { repo: gl[1], ref: gl[3], kind: gl[2] === "merge_requests" ? "mr" : "issue" };
+    const kinds: Record<string, ChangeRefKind> = {
+      merge_requests: "mr",
+      issues: "issue",
+      work_items: "issue",
+      epics: "epic",
+      milestones: "milestone",
+    };
+    return { repo: gl[1], ref: gl[3], kind: kinds[gl[2]] };
   }
   const glCommit = url.match(
     /^https:\/\/gitlab\.[^/]*\/.*?\/([^/]+)\/-\/commit\/([0-9a-f]+)/i,
@@ -645,11 +657,14 @@ function isPrOrMrUrl(url: string): boolean {
 
 // Canonical forge notation attaches a kind-specific sigil to the repo:
 // `repo#42` for a PR/issue, `repo!99` for an MR, `repo@<sha7>` for a commit.
+// Epics and milestones reuse GitLab's own reference syntax, `&` and `%`.
 const CHANGE_REF_SIGIL: Record<ChangeRefKind, string> = {
   pr: "#",
   issue: "#",
   mr: "!",
   commit: "@",
+  epic: "&",
+  milestone: "%",
 };
 
 export function deriveDeliverableLabel(url: string): string {
@@ -819,8 +834,20 @@ function findBy(accepts: (url: string) => boolean): FindMatch[] {
   return matches;
 }
 
+// GitLab serves one issue from two paths, so two recordings of the same issue
+// are not string-equal. Canonicalize the newer form onto the older one for
+// comparison only — stored URLs stay exactly as the caller gave them, since
+// that is the link the user actually followed.
+export function canonicalizeUrl(url: string): string {
+  return url.replace(
+    /^(https:\/\/gitlab\.[^/]*\/.*?\/-\/)work_items(\/\d+)/,
+    "$1issues$2",
+  );
+}
+
 export function find(url: string): FindMatch[] {
-  return findBy((u) => u === url);
+  const target = canonicalizeUrl(url);
+  return findBy((u) => canonicalizeUrl(u) === target);
 }
 
 // CLI-23a: return every tack whose deliverable or link URL belongs to the given


### PR DESCRIPTION
Closes #33

## Context

tack watches tool output and user prompts for forge URLs and nudges the agent to record any that no tack tracks yet. Both hooks share one regex, and a URL that regex misses is indistinguishable from no URL at all — the hook is silent either way, so a miss leaves no trace.

GitLab serves issues from `/-/work_items/<n>` as well as `/-/issues/<n>`, and only the latter matched. A session filed an issue through a self-hosted GitLab, printed the `work_items` URL to Bash output three times, and produced zero nudges and no record, with nothing indicating anything had been dropped. Epics and milestones are the same class of reference and matched nowhere.

## Review guide

**The pattern both hooks read** — [`lib-url.sh:9`](https://github.com/chris-peterson/tack/pull/38/changes#diff-181700ef847df749573120e80216d822d625399a0eb49746b7ff425458011e2aR9). `work_items` is added *alongside* `issues` rather than replacing it; the old form is still live and still resolves.

**Kinds and labels** — [`route.ts:635`](https://github.com/chris-peterson/tack/pull/38/changes#diff-634333527025d8043fae2cc51a501b3e6cc4a200276c061bcaa0a947b0e9c3f1R635). `work_items` derives the same `<repo>#<n>` and `issue` kind as `issues`. Epics and milestones get kinds of their own, labelled `<group>&<n>` and `<repo>%<n>` — [GitLab's own reference syntax](https://docs.gitlab.com/ee/user/markdown.html#gitlab-specific-references), the same basis `#` and `!` were picked on. Neither is a change request, so neither promotes to a deliverable on `tack done`.

**Where epics and milestones belong** — [`SKILL.md:149`](https://github.com/chris-peterson/tack/pull/38/changes#diff-e2910be6b19bad1f9d37fed5393192bf639a9ce7e0f2748867d9b72b7719dd2fR149). The issue asked for this to be written down rather than left to the agent reading a nudge. They're links: an epic is a container several tacks can share, so none of them *is* it.

**The behavior change worth your attention** — [`route.ts:841`](https://github.com/chris-peterson/tack/pull/38/changes#diff-634333527025d8043fae2cc51a501b3e6cc4a200276c061bcaa0a947b0e9c3f1R841). `find()` compared URLs by exact string equality, so one issue reachable at two paths read as two unrelated references: a route holding `/-/issues/9` wouldn't match a search for `/-/work_items/9`, and the duplicate-URL warning ([CLI-48]) stayed quiet while both accumulated on different tacks. Widening the hooks makes that collision likelier, so `find` now canonicalizes `work_items` onto `issues` before comparing. Comparison only — stored URLs keep the form the caller gave, since that's the link the user actually followed.

**Repo-database exclusion** — [`repos.ts:69`](https://github.com/chris-peterson/tack/pull/38/changes#diff-7bbcd86314b708a90785522fae3f1d54a9397f5df1cc10f392f652027781e94fR69). `work_items` contributes a repo key like `issues` does. Epics and milestones deliberately don't: both can be group-scoped (`/groups/<group>/-/…`), where the captured path segment is a group, and recording it would put a non-repo entry in the index.

**Also in this branch** — [`plans/1.0.md`](https://github.com/chris-peterson/tack/pull/38/changes#diff-17240a9a36548f5d0e33f7331a10a7d6f173032bc54564b0bcad7b4d47645277), the working plan for the 1.0 push. Separate commit, unrelated to the fix; it rides here so it reaches `main` with the work it describes.

Spec: new [CLI-37b]; [CLI-37] extended for `work_items`, [CLI-23] and [CLI-48] reworded for the match rule. Suite 329 → 341. `STATUS.md` is left for a `/sextant:spec-status` pass.

## Approach & trade-offs

The issue floated normalizing the two forms *on write* instead. Canonicalizing at compare time keeps the stored URL faithful to what the user saw, and avoids betting on which path GitLab treats as canonical long-term — if that flips, only the comparison needs revisiting, not recorded data.

Milestones can be project-scoped, so excluding them from the repo database gives up a legitimate capture in that case. A missed capture is recoverable (`tack repo rebuild`); a group recorded as a repo is a wrong entry someone has to find and delete.
