### PR TITLE
Report CLI failures as messages, not stack traces

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -206,6 +206,23 @@ function readVersion() {
         return "unknown";
     }
 }
+// Everything the CLI throws is an ordinary caller condition — an unknown flag,
+// a slug that doesn't exist, a schema rule the write would break — so the
+// message is the whole of what the caller can act on. Set TACK_DEBUG to get the
+// stack back when the throw is a genuine bug rather than a refusal.
+function fail(e) {
+    const err = e;
+    if (process.env.TACK_DEBUG) {
+        console.error(err?.stack ?? String(e));
+    }
+    else {
+        console.error(`tack: ${err?.message ?? String(e)}`);
+        // parseArgs names the offending flag but not where to look it up.
+        if (err?.code?.startsWith("ERR_PARSE_ARGS_"))
+            console.error("Run `tack --help` for usage.");
+    }
+    process.exit(1);
+}
 function run() {
     const args = process.argv.slice(2);
     if (args[0] === "--version" || args[0] === "-v") {
@@ -989,4 +1006,9 @@ function run() {
             usage();
     }
 }
-run();
+try {
+    run();
+}
+catch (e) {
+    fail(e);
+}

--- a/dist/cli.test.js
+++ b/dist/cli.test.js
@@ -758,6 +758,31 @@ describe("tack add --link splits label from url (issue #28)", () => {
         ]);
     });
 });
+describe("top-level error handler", () => {
+    it("reports a missing route as a message, not a stack trace", () => {
+        const r = runCapture(["status", "no-such-route"]);
+        assert.equal(r.status, 1);
+        assert.equal(r.stdout, "");
+        assert.match(r.stderr, /^tack: Route not found: no-such-route$/m);
+        assert.doesNotMatch(r.stderr, /\n\s+at /);
+    });
+    it("reports an unknown flag and points at --help", () => {
+        const r = runCapture(["done", "some-route", "t1", "--nope"]);
+        assert.equal(r.status, 1);
+        assert.match(r.stderr, /^tack: Unknown option '--nope'/m);
+        assert.match(r.stderr, /Run `tack --help` for usage\./);
+        assert.doesNotMatch(r.stderr, /\n\s+at /);
+    });
+    it("restores the stack under TACK_DEBUG", () => {
+        const r = spawnSync("node", [cli, "status", "no-such-route"], {
+            env: { ...env, TACK_DEBUG: "1" },
+            encoding: "utf-8",
+        });
+        assert.equal(r.status, 1);
+        assert.match(r.stderr, /Error: Route not found: no-such-route/);
+        assert.match(r.stderr, /\n\s+at /);
+    });
+});
 describe("tack rm refuses without --force", () => {
     it("puts the refusal on stderr and leaves stdout empty", () => {
         runFail(["init", "rm-refuse"]);

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -72,7 +72,7 @@ Repo database (1 YAML file, ~/.tack/repos.yaml)
 
 ## Requirements
 
-### RTE — Route Schema
+### ROUTE — Route Schema
 
 **[ROUTE-01]** The route schema shall use YAML as the on-disk format.
 
@@ -251,7 +251,7 @@ route files may not exist locally).
 
 ---
 
-### STG — Storage
+### STORE — Storage
 
 **[STORE-01]** Route files shall be stored in `~/.tack/routes/`.
 
@@ -809,6 +809,14 @@ stored verbatim except for trailing newlines, which shall be stripped so a piped
 file and an equivalent inline argument produce the same stored value. A body that
 is empty once stripped shall fail rather than store an empty description, since
 that reads as a truncated pipe and `--clear` already removes the field.
+
+**[CLI-55]** Failures not reported at the call site — a route or tack that does
+not exist, a schema rule the write would break, an unrecognized flag — shall
+reach the caller as a single `tack: <message>` line on stderr with a non-zero
+exit, not as an interpreter stack trace. A failure raised while parsing
+arguments shall additionally point at `tack --help` ([CLI-38]). Setting the
+`TACK_DEBUG` environment variable shall restore the stack, which a message
+cannot substitute for when the throw is a defect rather than a refusal.
 
 ---
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -870,6 +870,34 @@ describe("tack add --link splits label from url (issue #28)", () => {
   });
 });
 
+describe("top-level error handler", () => {
+  it("reports a missing route as a message, not a stack trace", () => {
+    const r = runCapture(["status", "no-such-route"]);
+    assert.equal(r.status, 1);
+    assert.equal(r.stdout, "");
+    assert.match(r.stderr, /^tack: Route not found: no-such-route$/m);
+    assert.doesNotMatch(r.stderr, /\n\s+at /);
+  });
+
+  it("reports an unknown flag and points at --help", () => {
+    const r = runCapture(["done", "some-route", "t1", "--nope"]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /^tack: Unknown option '--nope'/m);
+    assert.match(r.stderr, /Run `tack --help` for usage\./);
+    assert.doesNotMatch(r.stderr, /\n\s+at /);
+  });
+
+  it("restores the stack under TACK_DEBUG", () => {
+    const r = spawnSync("node", [cli, "status", "no-such-route"], {
+      env: { ...env, TACK_DEBUG: "1" },
+      encoding: "utf-8",
+    });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Error: Route not found: no-such-route/);
+    assert.match(r.stderr, /\n\s+at /);
+  });
+});
+
 describe("tack rm refuses without --force", () => {
   it("puts the refusal on stderr and leaves stdout empty", () => {
     runFail(["init", "rm-refuse"]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,6 +218,22 @@ function readVersion(): string {
 }
 
 
+// Everything the CLI throws is an ordinary caller condition — an unknown flag,
+// a slug that doesn't exist, a schema rule the write would break — so the
+// message is the whole of what the caller can act on. Set TACK_DEBUG to get the
+// stack back when the throw is a genuine bug rather than a refusal.
+function fail(e: unknown): never {
+  const err = e as NodeJS.ErrnoException;
+  if (process.env.TACK_DEBUG) {
+    console.error(err?.stack ?? String(e));
+  } else {
+    console.error(`tack: ${err?.message ?? String(e)}`);
+    // parseArgs names the offending flag but not where to look it up.
+    if (err?.code?.startsWith("ERR_PARSE_ARGS_")) console.error("Run `tack --help` for usage.");
+  }
+  process.exit(1);
+}
+
 function run(): void {
   const args = process.argv.slice(2);
 
@@ -1004,4 +1020,8 @@ function run(): void {
   }
 }
 
-run();
+try {
+  run();
+} catch (e) {
+  fail(e);
+}


### PR DESCRIPTION
## Context

tack is a CLI over a YAML route schema; most of what it refuses to do, it refuses on purpose — a route slug that doesn't exist, a tack id that isn't in the file, a write the schema would reject. Those refusals throw, and nothing catches them, so the caller gets a Node stack trace where a sentence would do. `tack status no-such-route` prints five frames of interpreter internals under one useful line, and a plain typo (`tack done tack t26 --deliverable x`) prints `ERR_PARSE_ARGS_UNKNOWN_OPTION` with a stack, which reads like tack crashed rather than like the flag doesn't exist.

It also works against [STORE-08], which requires a refused write to name the rule it broke. The message is there — wrapped in a trace that makes a deliberate refusal look like a defect.

Part of the [1.0 freeze](https://github.com/chris-peterson/tack/blob/main/plans/1.0.md), where it was carried as an open decision. Landing it now rather than after: it changes the observable output of *every* error path, which is exactly the kind of change a compatibility promise makes awkward to make later.

## Review guide

**The handler** — [`cli.ts:225`](https://github.com/chris-peterson/tack/pull/39/changes#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR225). `tack: <message>` on stderr, exit 1 — the shape `groupError` already uses for subcommand-group errors, so the two error surfaces now read alike. Argument-parsing failures get one extra line pointing at `tack --help`, since parseArgs names the offending flag but not where to look it up. `TACK_DEBUG` restores the stack; a message can't substitute for one when the throw is a defect rather than a refusal.

**Where it wraps** — [`cli.ts:1023`](https://github.com/chris-peterson/tack/pull/39/changes#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR1023). One catch at the entrypoint. Call sites that already report and exit (`groupError`, the `import` parse failure, the `rm` refusal) are untouched — they never reach it.

**The requirement** — [`SPEC.md:813`](https://github.com/chris-peterson/tack/pull/39/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R813), new [CLI-55]. Worth a read as contract text, since the 1.0 freeze will point at it: the `tack:` line and the non-zero exit are the promise, the message wording is not.

**Tests** — [`cli.test.ts:873`](https://github.com/chris-peterson/tack/pull/39/changes#diff-c6e5a65515030fb8ae1e75a91c25524498f612d5ce26ba2115a334e7974df5e6R873). Three: the message form, the unknown-flag hint, and `TACK_DEBUG` bringing the stack back. Each asserts on the *absence* of frames (`doesNotMatch(/\n\s+at /)`) rather than only on the message, so a regression that prints both still fails. Suite 341 → 344.

**Also in this branch** — [`SPEC.md:75`](https://github.com/chris-peterson/tack/pull/39/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R75). #37 renamed `RTE`→`ROUTE` and `STG`→`STORE` across every requirement id but left the two section headings, so the spec contradicted the category table in the root `SPEC.md`. Two words.

`STATUS.md` needs a `/sextant:spec-status` pass to absorb CLI-55.

## Approach & trade-offs

`TACK_DEBUG` is an env var rather than a flag because the throw can happen during flag parsing, which is the case where a flag is least reachable.
