### PR TITLE
Add the serve and reconcile sections to the docs sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,8 @@
   - [Deliverable](/cli?id=deliverable)
   - [Todos](/cli?id=todos)
   - [Links](/cli?id=links)
+  - [Reconcile](/cli?id=reconcile)
+  - [Documents](/cli?id=documents)
   - [Pinning](/cli?id=pinning)
   - [Backup](/cli?id=backup)
 - [Examples & Visualizations](/examples)


### PR DESCRIPTION
Follow-up to #43, which nested the sidebar off `main` before #42 landed — so it covered the eight CLI sections that existed then. `tack reconcile` and `tack serve` added two more, missing from the sidebar since.

All ten sidebar ids verified against the headings in `docs/cli.md`.

This is the hand-nesting drift #43 called out. It stops being a recurring chore if [shipyard#14](https://github.com/chris-peterson/shipyard/issues/14) or a `subMaxLevel` option lets docsify build the tree instead.