### PR TITLE
Add start and end skills to open and close a session

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Route tracker for AI-assisted development work \u2014 pivots, deliverables, and dependencies \u2014 across session boundaries",
   "author": {
     "name": "chris-peterson"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ docs/plugin-docs.json
 docs/preview.html
 docs/skills/
 docs/spec.md
+docs/spec/
+docs/_home.md
+docs/hooks.md
+docs/status.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ tack is not a project management system. It answers three questions:
   one concrete deliverable — an MR, a deployment, a script run. No sub-items,
   no hierarchy.
 - **Dependencies, not workflows.** Tacks declare what they depend on. There is
-  no enforced state machine or prescribed workflow.
+  no enforced state machine or prescribed workflow. The skills that open and
+  close a route ask before closing on work that isn't durable yet; they name
+  the commands that would advance it rather than running them.
 - **Tool-agnostic core.** The schema has no assumptions about Claude Code,
   Cursor, Windsurf, or any specific AI coding tool. Integrations are packaging
   concerns, not schema concerns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **`/tack:start` and `/tack:end` open and close a session.** A route had no defined beginning or end — you created one by hand and remembered to close it. `/tack:start` reads the linked issue or change request in full (the whole thread, not the note the link anchors), derives one slug, cuts the branch from the freshly fetched default rather than whatever is checked out, and creates the route. `/tack:end` reads git and forge state fresh, refuses to close on work that only exists in your working tree, records the deliverable, and reports the commands still owed — it never runs them. Both skills came from a personal toolkit where they had been in daily use; the spec categories SESSION, BRIEF, DURABILITY, and FALLBACK are what they look like written down.
+- **A change-request description landing now prompts the handoff report.** The first moment a session has something reviewable is the moment you want one block saying where it stands and what's next. A `PostToolUse` hook detects the description write and asks for `/tack:end`'s table right there, once per session.
+
+### Changed
+
+- **The anti-requirements now say which layer they bind.** "No git operations" and "no enforced workflows" always described the CLI and the schema — the tool-agnostic half a consumer builds on. The skill layer reads git and cuts a branch, and `/tack:end` holds a durability floor. Both are still true where they were always meant to apply: nothing git-derived enters a route, and the floor asks rather than blocking a transition the CLI allows.
+- **Route resolution retries until it binds.** The `UserPromptSubmit` hook resolved the session's route once per session, which meant a session opened with `/tack:start` was probed before the route existed and never looked at again — unattributed for its whole life. Resolution now runs every prompt until it succeeds; only the "no route resolves" nudge still fires once.
+
 ### Fixed
 
 - **`scripts/shipyard` works on a machine that hasn't run it before.** It reset its cached checkout to `origin/v1`, a remote-tracking branch that stopped existing when shipyard began publishing `v1` as a tag: the first run cloned and worked, and every run after it failed with `fatal: ambiguous argument 'origin/v1'`. A cache created before that switch kept resolving the stale ref instead, pinning the build tooling to whatever commit it still pointed at. Both cases now reset to the fetched ref, which resolves a tag and a branch alike.
@@ -179,7 +189,7 @@ Fixes session→tack binding, which silently did nothing because the code and th
 ### Features
 
 - **Sessions link to the specific tack they're driving.** `tack session <slug> <session-id> --tack <tack-id>` binds a session to a tack within the route, stored as a `tacks` array on the session entry (touch order, last = current focus). A session was previously associated only with a route, so a fleet view could group live sessions by route but not show which tack each one was working. Re-binding a tack moves it to the end, so a pivot back to an earlier tack makes it current again (ROUTE-11, CLI-17).
-- **The skill establishes the session→tack link early from a tracker URL.** When a PR/MR/issue URL is in scope at session start, the tack skill runs `tack find` on it — a match binds the session to the existing tack, no match means emerging work (create the tack, then bind) — so a dashboard can tell resumed/tracked work from work spun up fresh in the session. Whether work is existing or emerging is read off the bound tack's own state (does it carry a deliverable or tracker link?), not stored as a flag (AGT-11).
+- **The skill establishes the session→tack link early from a tracker URL.** When a PR/MR/issue URL is in scope at session start, the tack skill runs `tack find` on it — a match binds the session to the existing tack, no match means emerging work (create the tack, then bind) — so a dashboard can tell resumed/tracked work from work spun up fresh in the session. Whether work is existing or emerging is read off the bound tack's own state (does it carry a deliverable or tracker link?), not stored as a flag (AGENT-11).
 
 ## 0.17.0
 
@@ -303,7 +313,7 @@ Closes #1.
 - New `tack pin <slug>` / `tack unpin` commands persist the active route for a working directory in a `.tack` YAML file at the cwd root. The tack skill reads the pin first when resolving "what am I working on?", so pinned routes win over branch-slug or single-open-route heuristics. Commit the file for shared assignment or `.gitignore` it for per-dev state.
 
 ### Architecture
-- Spec now states the layering explicitly: the CLI encapsulates schema operations as a deterministic primitive; the skill owns reasoning (route resolution, ambiguity prompts, URL capture); hooks emit advisory reminders. The CLI no longer reaches into inference — that lives entirely in `skills/tack/SKILL.md`. New `[STORE-06]` covers the pin file format; new `[CLI-30]`/`[CLI-31]` cover the pin/unpin commands; AG- expanded with a formal resolution procedure (`[AGT-03]`) and pin discipline (`[AGT-10]`); new **HK** category formalizes what each hook does.
+- Spec now states the layering explicitly: the CLI encapsulates schema operations as a deterministic primitive; the skill owns reasoning (route resolution, ambiguity prompts, URL capture); hooks emit advisory reminders. The CLI no longer reaches into inference — that lives entirely in `skills/tack/SKILL.md`. New `[STORE-06]` covers the pin file format; new `[CLI-30]`/`[CLI-31]` cover the pin/unpin commands; AG- expanded with a formal resolution procedure (`[AGENT-03]`) and pin discipline (`[AGENT-10]`); new **HK** category formalizes what each hook does.
 - Hook reminder text now points at the tack skill rather than naming specific CLI commands, routing all writes through one path (the skill) so context (which slug, which tack) is applied by the only component that sees it.
 
 ## 0.9.1
@@ -314,7 +324,7 @@ Closes #1.
 
 ### Other
 - Spec catches up to the shipped CLI: `tack edit`, `tack merge`, and `tack --version` are now formal requirements [CLI-27], [CLI-28], [CLI-29].
-- Wording tightened on [TACK-04] (gating responsibility lies with the caller, not the CLI), [AGT-02] ("background" → "without blocking the user prompt"), and [AGT-03] (matches the actual `UserPromptSubmit` + branch-slug heuristic, not the URL inference that never shipped).
+- Wording tightened on [TACK-04] (gating responsibility lies with the caller, not the CLI), [AGENT-02] ("background" → "without blocking the user prompt"), and [AGENT-03] (matches the actual `UserPromptSubmit` + branch-slug heuristic, not the URL inference that never shipped).
 - New `STATUS.md` tracks spec coverage (73/73 normative + 5 deferred) and an advisory backlog for the next audit.
 
 ## 0.9.0

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Full contract: the COMPAT requirements in [`spec/v1/SPEC.md`](spec/v1/SPEC.md).
 - **The schema is the product.** The CLI is a convenience wrapper. Any tool that reads/writes conforming YAML is a first-class citizen.
 - **One file per route.** Easy to list, archive, delete, or version-control.
 - **Flat over nested.** A tack is one unit of work with one deliverable. No sub-items.
-- **Dependencies, not workflows.** Tacks declare what they depend on. No enforced state machine.
+- **Dependencies, not workflows.** Tacks declare what they depend on. No enforced state machine. The skills that open and close a route ask before closing on work that isn't durable yet, and name the next commands rather than running them.
 - **Local only.** No server, no sync, no cloud.
 
 ## License

--- a/SPEC.md
+++ b/SPEC.md
@@ -62,13 +62,17 @@ Route (1 YAML file per route)
 |---|---|
 | ROUTE | Route schema structure and constraints |
 | TACK | Tack fields, statuses, and ID sequencing |
-| DEL | Deliverable (single change request per tack) |
+| DELIVER | Deliverable (single change request per tack) |
 | TODO | Todo items (before/after arrays with IDs) |
-| DEP | Dependency tracking and enforcement |
-| LINK | Link structure (label + url) |
+| DEPENDS | Dependency tracking and enforcement |
+| LINKS | Link structure (label + url) |
 | STORE | Storage location, directory creation, validation, cwd pointer file |
 | CLI | CLI commands and output behavior |
-| AGT | Claude Code agent integration (skill responsibilities) |
+| AGENT | Claude Code agent integration (skill responsibilities) |
+| SESSION | Opening and closing a session — the `start` and `end` skills |
+| BRIEF | Reading the linked issue or change request in full |
+| DURABILITY | Durability floor a session must clear before it closes |
+| FALLBACK | Behavior when an optional companion plugin is absent |
 | HOOK | Hook responsibilities (nudges, freshness checks) |
 | REPO | Repo database (name→remote index, captured as work is observed) |
 | SERVE | Loopback document server and the terminal hyperlinks into it |
@@ -96,7 +100,9 @@ Explicitly out of scope:
 
 - No project management (sprints, epics, story points)
 - No time tracking
-- No git operations
-- No enforced workflows beyond dependency constraints
+- No git operations in the CLI or schema — the skill layer cuts the branch a
+  route is named for, and nothing git-derived is stored in a route
+- No enforced workflows beyond dependency constraints — the skill layer's
+  durability floor asks before closing, and never blocks
 - No sync, no cloud, no non-loopback bind — the two commands that leave the local files are `tack reconcile`, which asks the git forge (GitHub, GitLab) what merged, and `tack serve`, which renders those files to `127.0.0.1`
 - No cross-route dependency enforcement

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,9 +3,9 @@
 Tracking status of the requirements declared in [`spec/v1/SPEC.md`](spec/v1/SPEC.md).
 Updated after each `/sextant:spec-status` or `/sextant:spec-sync` run.
 
-**Last audit:** 2026-08-05
+**Last audit:** 2026-08-14
 **Spec version:** v1
-**Coverage:** 164 / 164 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts
+**Coverage:** 190 / 190 source-verified normative behaviors (100%) — 0 Partial, 0 Missing, 0 Contradicts
 
 This `/sextant:spec-sync` pass captured one drift item: the new
 `tack merge-routes` command (issue #8) shipped without a requirement. Added as
@@ -22,19 +22,32 @@ Source-verified count moves 122 → 127.
 |--------|------:|--------|-------|
 | ROUTE-01..14 (routes) | 14 | All Covered | `src/types.ts`, `schema/route.schema.json`, `src/route.ts`; ROUTE-04 optional fields now include `title`/`description` (`Route` in `src/types.ts`, rendered by `formatRoute` in `src/display.ts`); includes ROUTE-09/ROUTE-10 sessions and ROUTE-11 session→tack binding (`Session.tacks`); ROUTE-12 states the slug pattern enforced by `schema/route.schema.json` and `assertValidSlug` (`src/route.ts`); ROUTE-13 derived route state (`routeState` in `src/route.ts`, surfaced by `formatRoute`/`formatList` in `src/display.ts` and the `--json` paths in `src/cli.ts`, never written to the file); ROUTE-14 `created_at` floor (`floorCreatedAt`, applied in `save`) |
 | TACK-01..08 (tacks) | 8 | All Covered | `src/route.ts`; TACK-08 bare-id resolution (`normalizeTackId`) |
-| DEL-01..02 (deliverables) | 2 | All Covered | `src/types.ts`, `src/route.ts` |
+| DELIVER-01..02 (deliverables) | 2 | All Covered | `src/types.ts`, `src/route.ts` |
 | TODO-01..05 (todos) | 5 | All Covered | `src/route.ts`; TODO-01 reworded to shall form |
-| DEP-01..04 (dependencies) | 4 | All Covered | `src/route.ts` |
-| LINK-01 (links) | 1 | Covered | `src/types.ts` |
+| DEPENDS-01..04 (dependencies) | 4 | All Covered | `src/route.ts` |
+| LINKS-01 (links) | 1 | Covered | `src/types.ts` |
 | STORE-01..09 (storage) | 9 | All Covered | `src/route.ts`; STORE-06 pins file (`~/.tack/pins.yaml`); STORE-07 filename↔`slug` agreement enforced in `load`; STORE-08 boundary slug checks (`assertValidSlug`, called from `init`, `rename`, `setGroup`, `mergeRoutes`), tests in `src/route.test.ts`; STORE-09 read-everything commands fail on the first unreadable file rather than skipping it (`loadAll` reads every route through `load`) |
 | CLI-01..56 (commands; +CLI-08a, CLI-19a, CLI-21a..d, CLI-23a..b, CLI-36a..d, CLI-37a..b, CLI-52a..d, CLI-54a, CLI-56a..b) | 77 | All Covered | CLI-53/CLI-54/CLI-54a (`tack title` and `tack describe` show/set/clear, plus `describe`'s `--file <path>` / `--file -` body input, trailing-newline stripping, and the empty-body refusal — `title`/`describe` dispatch and `readDescriptionBody` in `src/cli.ts`, `setTitle`/`clearTitle`/`setDescription`/`clearDescription` in `src/route.ts`, tests in `src/cli.test.ts`/`src/route.test.ts`); CLI-14 carries the route `title` in the text listing (`list` in `src/route.ts`, `formatList` in `src/display.ts`), while the `--json` form serializes the full route (`loadAll` in `src/route.ts`); CLI-52c title/description carry-over on merge (`mergeRoutes` in `src/route.ts`); CLI-23a/CLI-23b (`tack find --path` path lookup and the exactly-one `--url`/`--path` selector guard — `repoKeyForCwd` in `src/repos.ts`, `findByRepoKey` in `src/route.ts`, `find` dispatch in `src/cli.ts`, tests in `src/route.test.ts`/`src/cli.test.ts`); CLI-52 (`tack merge-routes`, whole-route consolidation with chronological destination IDs, metadata/`depends_on`/session preservation, `created_at`/group defaults, external route-dep guard — `mergeRoutes` in `src/route.ts`, `merge-routes` dispatch in `src/cli.ts`, tests in `src/route.test.ts`); CLI-51 (`tack group` show/set/clear, `src/cli.ts` group case + `setGroup`/`clearGroup` in `src/route.ts`); also includes CLI-02/CLI-04 (`init`/`add` record the current session route-level via `recordSessionIfPresent`, `src/cli.ts`; CLI-04 also takes repeatable `--link "label,url"`, deduped in `addTack`), CLI-08a (`deliverable rm` clears or `--to-link`-demotes the deliverable, `src/route.ts` `removeDeliverable` + `src/cli.ts` dispatch, tests in `src/route.test.ts`/`src/cli.test.ts`), CLI-17/CLI-18 (session + `--tack` binding / `--json`), CLI-19a (`install-cli`), CLI-30..36 (pin/unpin, depends add/rm, status set, rename, move), CLI-37 (forge note) + CLI-37a (commit-URL label derivation), CLI-38 (`--help`/`-h`/`help` + usage exit semantics, incl. subcommand-level `--help`/`-h`, `src/cli.ts`), CLI-39/CLI-40 (`tack pins` list + prune, `src/route.ts` `listPins`/`prunePins`), CLI-41 (group-scoped subcommand errors on stderr, `src/cli.ts` `groupError`, `src/cli.test.ts`), CLI-42..47 (`tack repo` lookup/list/alias/prune/rebuild/rm, `src/repos.ts` + `src/cli.ts`), CLI-48 (duplicate-URL warning on attach, `src/route.ts` `findCollisions`, `src/cli.ts` `warnUrlCollision`, `src/cli.test.ts`), CLI-49/CLI-50 (`export` to stdout by default with `--out-file`/`--compress`, `import` detecting gzip-vs-plain by content, schema versioning + identity-dedup merge, `src/backup.ts` + `src/cli.ts`, `src/cli.test.ts`); CLI-04 `--link` splits at the first comma whose suffix parses as a URL (commas allowed in label and URL), CLI-15 `rm` refusal on stderr with a non-zero exit, CLI-51 group checked at the boundary per STORE-08 — all three reworded, no new IDs; CLI-37b GitLab `work_items`/epics/milestones recognition (`parseChangeRefUrl` in `src/route.ts`, `scripts/lib-url.sh`); CLI-55 top-level error handler (`fail` in `src/cli.ts`, `TACK_DEBUG` restores the stack, tests in `src/cli.test.ts`); CLI-56/CLI-56a/CLI-56b `tack reconcile` — candidate selection, forge merge-timestamp `done_at`, and the gh/glab-only network path (`reconcile`/`mergeState` in `src/reconcile.ts`, `reconcile` dispatch in `src/cli.ts`, 8 tests in `src/reconcile.test.ts` driving an injected probe) |
-| AGT-01..11 (agent) | 11 | All Covered | AGT-02 reworded to drop "without blocking"; AGT-10 (auto-pin on confident resolution); AGT-11 (early session→tack binding via `tack find`, existing-vs-emerging derivation) covered in `skills/tack/SKILL.md` |
-| HOOK-01..05 (hooks) | 5 | All Covered | HOOK-02/HOOK-03 gate the URL reminder on `tack find` (already-tracked URLs stay silent; untracked ones nudge to create the mapping), shared in `scripts/lib-url.sh`; HOOK-04 records the session route-level when a route resolves; HOOK-05 permits the hook's deterministic reads (`tack find`) and the route-level session write while keeping URL→tack mapping with the agent |
+| AGENT-01..11 (agent) | 11 | All Covered | AGENT-02 reworded to drop "without blocking"; AGENT-10 (auto-pin on confident resolution); AGENT-11 (early session→tack binding via `tack find`, existing-vs-emerging derivation) covered in `skills/tack/SKILL.md` |
+| SESSION-01..10 (open and close) | 10 | All Covered | `skills/start/SKILL.md` (SESSION-01..05: the gate, slug derivation via `skills/start/scripts/parse-start-args.py`, fresh-base branch cut, and the no-`tack session` rule) and `skills/end/SKILL.md` (SESSION-06..09: the non-sequencing boundary, the step-5 output table, the dead-end bookkeeping); SESSION-10 stated in both — neither skill writes an external session label |
+| BRIEF-01..04 (linked artifact) | 4 | All Covered | `skills/start/SKILL.md` ("Read the linked artifact in full"): whole-thread fetch, the fragment-anchors-a-position rule, and stating back what the thread settled |
+| DURABILITY-01..04 (the floor) | 4 | All Covered | `skills/end/SKILL.md` step 2: the three levels, the ask-never-block rule, the draft-flag stall, and the dead-end exemption |
+| FALLBACK-01..05 (absent companions) | 5 | All Covered | FALLBACK-01/02 in `skills/end/SKILL.md` preamble (read the skill listing; name raw `gh`/`glab`/`git` when no forge skill resolves), FALLBACK-03 in its step 4 + footer rule, FALLBACK-04 in `skills/start/SKILL.md`'s handoff rule (incl. the `tack.handoff` override); FALLBACK-05 both skills state which step was dropped rather than skipping silently |
+| HOOK-01..06 (hooks; +HOOK-04a..b) | 8 | All Covered | HOOK-02/HOOK-03 gate the URL reminder on `tack find` (already-tracked URLs stay silent; untracked ones nudge to create the mapping), shared in `scripts/lib-url.sh`; HOOK-04 records the session route-level when a route resolves, HOOK-04a retries every prompt until bound (`.bound` marker in `hooks/session-nudge.sh`) so a route created mid-turn by `start` is still attributed, HOOK-04b debounces only the nudge text (`.nudged` marker) and suppresses it on a prompt that already opens a session or outside a git repo; HOOK-05 permits the hook's deterministic reads (`tack find`) and the route-level session write while keeping URL→tack mapping with the agent; HOOK-06 the change-request-description handoff prompt (`hooks/landing-nudge.sh`) |
 | REPO-01..07 (repo db) | 7 | All Covered | `~/.tack/repos.yaml` repo database (`src/repos.ts`): REPO-02 remote normalization, REPO-06 capture from deliverable/link URLs, REPO-07 capture from `init`/`pin` cwd origin; tests in `src/repos.test.ts`, `src/cli.test.ts` |
 | SERVE-01..14 (document server; +SERVE-02a) | 15 | All Covered | `src/serve.ts` (`serve`, `handle`, `renderIndex`/`renderRoute`/`renderGroup`, `prefersJson`, `loopbackHost`, `sameOrigin`, `markdown`, `hyperlinkBase`) and `src/service.ts` (`install`/`uninstall`/`status`, `renderPlist`/`renderUnit`); SERVE-02a group documents link out rather than anchoring in place; SERVE-09 OSC 8 links rendered by `formatRoute`/`formatTack` in `src/display.ts` from the base `src/cli.ts` resolves; SERVE-12/SERVE-13 the edit form and its `Origin` check; 28 tests in `src/serve.test.ts`, 5 in `src/service.test.ts`. SERVE-08's launchd/systemd load-unload round trip is exercised by hand, not by the suite |
 | COMPAT-01..06 (compatibility) | 6 | All Covered | The contract itself is prose in `spec/v1/SPEC.md`, summarized in `SPEC.md` and `README.md`; the parts with a gate: COMPAT-02's closed schema (`additionalProperties: false` throughout `schema/route.schema.json`), COMPAT-05's grammar snapshot (`spec/v1/cli-usage.txt` vs `tack --help`, asserted in `src/cli.test.ts`), COMPAT-06's archive version guard (`SCHEMA_VERSION` in `src/backup.ts`, refusal tested in `src/cli.test.ts`). COMPAT-01/03/04 are declarations a reviewer applies, with no code path to point at |
 
 ## Audit history
+
+### 2026-08-14 — Coverage refresh (spec-status)
+
++26 IDs, coverage 164 → 190, all Covered, no needs-decision rows.
+Four new categories for the promoted start/end skills — SESSION-01..10, BRIEF-01..04,
+DURABILITY-01..04, FALLBACK-01..05 — plus HOOK-04a/04b (resolution retries until bound;
+only the nudge text debounces) and HOOK-06 (the change-request-description
+handoff prompt). FALLBACK-05 landed in the same pass — both skills now name the step
+they dropped when an optional companion is absent.
 
 ### 2026-08-05 — Coverage refresh (spec-status)
 
@@ -117,9 +130,9 @@ shipping code (the user's "source wins" call) plus one skill completion:
 - **CLI-51 (`tack group`) drift → spec.** The shipping `tack group <slug>
   [<group>] [--clear]` show/set/clear-group command had no requirement; added as
   CLI-51 (`src/cli.ts` group case, `setGroup`/`clearGroup` in `src/route.ts`).
-- **AGT-04 skill gap.** `skills/tack/SKILL.md` resolution step 5 pinned a
+- **AGENT-04 skill gap.** `skills/tack/SKILL.md` resolution step 5 pinned a
   not-yet-created slug on the "start a new route" pick; it now runs `tack init`
-  + first `tack add` before pinning, per AGT-04.
+  + first `tack add` before pinning, per AGENT-04.
 
 Two doc corrections outside the count: the public root `SPEC.md` category table
 carried the pre-2026-07-08 prefixes (`RT`/`TK`/…) and omitted REPO — refreshed
@@ -209,13 +222,13 @@ being silently ignored by manually-parsed ones. No new ID; count holds at 104.
 
 ### 2026-06-15 — 0.18.0 (session→tack link)
 
-+2 IDs (ROUTE-11, AGT-11). **ROUTE-11** adds the optional `tacks` array to each session
++2 IDs (ROUTE-11, AGENT-11). **ROUTE-11** adds the optional `tacks` array to each session
 entry — the bare route-scoped tack IDs a session is driving, in touch order
 (last = current focus). This narrows the existing session→route record (ROUTE-09)
 to the specific tack(s) a session works, so a fleet view keyed on the Claude
 session id can resolve which tack a live session is on. **CLI-17** gains
 `--tack <tack-id>`, which appends the tack to the session entry (move-to-end on
-re-bind, validated against the route). **AGT-11** has the skill establish the
+re-bind, validated against the route). **AGENT-11** has the skill establish the
 link as early as possible: a work-tracker URL in scope at session start is run
 through `tack find`; a match binds the session to the existing tack, no match
 means emerging work (create + bind). Existing-vs-emerging is derived from the
@@ -256,17 +269,17 @@ by counting decompositions as part of their parent.
 Reconciled STATUS.md against the current spec inventory (87 normative + 5
 deferred). Rebuilt the category table to include requirements added since the
 prior audit: the HOOK category (HOOK-01..05), CLI-30..36, CLI-17/CLI-18, CLI-19a,
-AGT-10, STORE-06, and ROUTE-09/ROUTE-10.
+AGENT-10, STORE-06, and ROUTE-09/ROUTE-10.
 
 Took the spec-alignment direction on the two gaps and brought both to
 **Covered** without touching code:
 
-- **[AGT-02]** Reworded to drop the unenforceable "without blocking the user
+- **[AGENT-02]** Reworded to drop the unenforceable "without blocking the user
   prompt" clause; it now states the skill loads all active routes when a
   session begins. (A `SessionStart`-hook prefetch remains deferred feature
   work, not a spec guarantee.)
 - **[HOOK-04]** Reworded to match `hooks/session-nudge.sh`: the hook checks
-  AGT-03 step 1 (pin at cwd) and step 3 (branch-slug route), existence-only,
+  AGENT-03 step 1 (pin at cwd) and step 3 (branch-slug route), existence-only,
   without verifying open-tack state. Dropped the "steps 1–4" claim.
 
 Also resolved the standing forge-support backlog item and applied EARS polish:
@@ -305,8 +318,8 @@ swallowed bad input).
   - Added `[CLI-29]` `tack --version` / `-v`.
   - Tightened `[TACK-04]` to acknowledge that the CLI persists status before
     surfacing pending after-items; gating is the caller's responsibility.
-  - Tightened `[AGT-02]` ("background" → "without blocking the user prompt").
-  - Tightened `[AGT-03]` to reflect the actual implementation
+  - Tightened `[AGENT-02]` ("background" → "without blocking the user prompt").
+  - Tightened `[AGENT-03]` to reflect the actual implementation
     (`UserPromptSubmit` hook + branch-slug heuristic), not the
     URL-inference language that never shipped.
 
@@ -340,7 +353,7 @@ swallowed bad input).
     will load successfully and later save to the filename, silently
     renaming.
   - EARS conformance polish for the "list of fields" requirements (ROUTE-03,
-    ROUTE-04, ROUTE-09, ROUTE-10, TACK-01, TACK-02, TODO-02, DEL-02, LINK-01). These remain
+    ROUTE-04, ROUTE-09, ROUTE-10, TACK-01, TACK-02, TODO-02, DELIVER-02, LINKS-01). These remain
     acceptable Ubiquitous form. (TODO-01 reworded to shall form and CLI-21
     decomposed into sub-requirements on 2026-05-31.)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,10 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/capture-urls.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/landing-nudge.sh"
           }
         ]
       }

--- a/hooks/hooks.yml
+++ b/hooks/hooks.yml
@@ -5,8 +5,12 @@ hooks:
     description: Detects when the installed tack CLI wrapper is stale relative to the plugin version and nudges to refresh it.
   - event: UserPromptSubmit
     command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-nudge.sh'
-    description: Detects untracked PR/MR/issue URLs in user messages and, on the first prompt of a session, resolves and records the session's tack route.
+    description: Detects untracked PR/MR/issue URLs in user messages, resolves and records the session's tack route, and recommends opening one when none resolves.
   - event: PostToolUse
     matcher: Bash
     command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/capture-urls.sh'
     description: Detects PR/MR/issue URLs in Bash tool output and nudges the agent to ensure a tack route mapping exists for each.
+  - event: PostToolUse
+    matcher: Bash
+    command: 'bash ${CLAUDE_PLUGIN_ROOT}/hooks/landing-nudge.sh'
+    description: Detects a change-request description landing and prompts the handoff report the end skill defines, so it isn't produced from recall.

--- a/hooks/landing-nudge.sh
+++ b/hooks/landing-nudge.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PostToolUse(Bash) hook — when a CR description lands, prompt the handoff
+# report rather than leaving it to recall.
+#
+# Writing the description is the moment the session first has a reviewable
+# thing, and the moment the user needs one block: where it stands and what's
+# owed. The `end` skill owns that block; the failure this hook removes is
+# producing it only when the agent happens to remember to.
+#
+# Stdin: JSON with "tool_input.command", "session_id" fields.
+# Stdout: reminder text, which reaches the agent as tool feedback.
+
+set -euo pipefail
+
+input=$(cat)
+command_text=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+[ -z "$command_text" ] && exit 0
+[ -z "$session_id" ] && exit 0
+
+has() { printf '%s' "$command_text" | grep -Fq -- "$1"; }
+
+# The description write, per forge: `gh pr edit --body-file` on GitHub, a
+# `description=@<file>` PUT on GitLab. Both are file-passed, which is what
+# separates them from `gh issue create --body-file` and from a comment.
+landing=0
+if has "gh pr " && has "--body-file"; then landing=1; fi
+if has "merge_requests" && has "description=@"; then landing=1; fi
+[ "$landing" -eq 1 ] || exit 0
+
+# Once per session, and only charged when the nudge actually fires — a session
+# that revises the description twice is still at one handoff point.
+nudge_dir="${TMPDIR:-/tmp}/tack-landing-nudge"
+mkdir -p "$nudge_dir"
+nudge_file="${nudge_dir}/${session_id}"
+[ -f "$nudge_file" ] && exit 0
+touch "$nudge_file"
+
+cat <<'EOF'
+A CR description just landed, so the session is at a handoff point.
+
+Once the CR reporting is done, close the turn with one table in the `end`
+skill's shape rather than a prose recap: a `change | state | next` row per thing
+to act on, with `next` carrying the commands in the order they run, then the
+bold-labelled `route` / `retro` / `notes` footer. Step 5 of that skill is the
+spec. This is a preview of the close, not the close — `/tack:end` still records
+the deliverable on the route and hands off the retro.
+EOF

--- a/hooks/session-nudge.sh
+++ b/hooks/session-nudge.sh
@@ -2,8 +2,15 @@
 # UserPromptSubmit hook — two responsibilities:
 #   1. Detect PR/MR/issue URLs pasted by the user that no tack tracks yet, and
 #      nudge the agent to ensure a route/tack mapping exists.
-#   2. On the first message of a session, resolve the tack route for the current
-#      repo/branch. If one exists, record the session on it; if not, nudge.
+#   2. Resolve the tack route for the current repo/branch. If one exists, record
+#      the session on it; if not, recommend opening one.
+#
+# Resolution retries every prompt until it binds, rather than running once per
+# session. A session that opens with `/tack:start` has no route at its first
+# prompt — the skill creates one mid-turn — so a once-per-session probe would
+# look before the route exists and never look again, leaving the session
+# unattributed for its whole life. The nudge text is still once per session; only
+# the resolution repeats.
 #
 # Stdin: JSON with "prompt", "cwd", "session_id" fields.
 # Stdout: reminder text (injected as system context for the agent).
@@ -24,14 +31,13 @@ output=""
 # --- 1. URL detection ---
 output="${output}$(url_nudges "$prompt" "PR/MR/issue URL in user message:")"
 
-# --- 2. Session nudge (once per session) ---
-nudge_dir="${TMPDIR:-/tmp}/tack-nudge"
-mkdir -p "$nudge_dir"
-nudge_file="${nudge_dir}/${session_id}"
+# --- 2. Route resolution, and the open-a-session nudge ---
+state_dir="${TMPDIR:-/tmp}/tack-nudge"
+mkdir -p "$state_dir"
+bound_file="${state_dir}/${session_id}.bound"
+nudged_file="${state_dir}/${session_id}.nudged"
 
-if [ ! -f "$nudge_file" ] && command -v tack >/dev/null 2>&1; then
-  touch "$nudge_file"
-
+if [ ! -f "$bound_file" ] && command -v tack >/dev/null 2>&1; then
   resolved_slug=""
 
   # Step 1: pin recorded for cwd (stored in ~/.tack/pins.yaml; `tack pin` with
@@ -62,9 +68,20 @@ if [ ! -f "$nudge_file" ] && command -v tack >/dev/null 2>&1; then
     # `|| true` keeps a tack write failure from ever breaking the user's prompt.
     if [ -n "$session_id" ]; then
       tack session "$resolved_slug" "$session_id" >/dev/null 2>&1 || true
+      touch "$bound_file"
     fi
-  else
-    output="${output}No tack route resolves for this cwd (no pin, no branch-slug match). Use the tack skill to identify or create a route for this work — the skill owns route resolution and will prompt if needed.\n"
+  elif [ ! -f "$nudged_file" ]; then
+    touch "$nudged_file"
+    # A prompt that already opens a session needs no recommendation to, and
+    # outside a git repo there is no branch for a route to answer to.
+    case "$prompt" in
+      */start*) ;;
+      *)
+        if [ -n "$cwd" ] && [ -d "$cwd/.git" ]; then
+          output="${output}No tack route resolves for this cwd (no pin, no branch-slug match).\n\nIf this turns out to be work rather than a question — it will span turns and produce a deliverable — recommend the user run \`/tack:start [issue-url]\` before starting: it reads the linked thread in full, derives one slug, cuts the branch, and binds the route the work gets recorded against. \`/tack:end\` closes it.\n\nFor a one-off question, a read-only investigation, or a mechanical one-liner, say nothing about this.\n"
+        fi
+        ;;
+    esac
   fi
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,7 @@
 # the marketplace SPA (the suite: block).
 
 name: tack
-version: 1.0.0
+version: 1.1.0
 description: Route tracker for AI-assisted development work — pivots, deliverables, and dependencies — across session boundaries
 author: chris-peterson
 repository: https://github.com/chris-peterson/tack
@@ -24,6 +24,8 @@ suite:
   pitch: "Keep losing your place between sessions? It remembers what you were doing so you don't re-explain it every time."
   what: "Tracks what you're working on — across crashes, context overflow, or jumping between projects. Start a fresh session and pick up exactly where you left off."
   cmds:
+    - ["/tack:start", "Open a session — read the ticket, cut the branch, bind the route"]
+    - ["/tack:end", "Close it — record what landed, report what's still owed"]
     - ["/tack:tack", "Resume — what you were doing, and where you stopped"]
     - ["tack", "Track routes, tasks, and deliverables from any terminal"]
   # Skill-anchored previews of the flagship flows, shown live on the docs site;
@@ -31,12 +33,15 @@ suite:
   # >>> shipyard:describe — generated from source by `shipyard gen-describe`; do not edit >>>
   describe:
     skills:
+      end: 'Close a work session: read what actually landed, refuse to close on work that isn''t durable yet, record the deliverable on the tack route, hand off the retro, and report the commands still owed rather than sequencing them.'
+      start: 'Open a work session: read the linked issue or CR thread in full, derive one slug, cut the branch, and bind the tack route.'
       tack: Track AI-assisted development work with the `tack` route tracker, spanning session boundaries.
     hooks:
       capture-urls: PostToolUse — Detects PR/MR/issue URLs in Bash tool output and nudges the agent to ensure a tack route mapping exists for each.
       cli-freshness: SessionStart — Detects when the installed tack CLI wrapper is stale relative to the plugin version and nudges to refresh it.
-      hooks: 'Hook wiring: SessionStart→cli-freshness; UserPromptSubmit→session-nudge; PostToolUse→capture-urls (Bash).'
-      session-nudge: UserPromptSubmit — Detects untracked PR/MR/issue URLs in user messages and, on the first prompt of a session, resolves and records the session's tack route.
+      hooks: 'Hook wiring: SessionStart→cli-freshness; UserPromptSubmit→session-nudge; PostToolUse→capture-urls (Bash), landing-nudge (Bash).'
+      landing-nudge: PostToolUse — Detects a change-request description landing and prompts the handoff report the end skill defines, so it isn't produced from recall.
+      session-nudge: UserPromptSubmit — Detects untracked PR/MR/issue URLs in user messages, resolves and records the session's tack route, and recommends opening one when none resolves.
   # <<< shipyard:describe <<<
   examples:
     - label: "/tack:tack"

--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: end
+description: "Close a work session: read what actually landed, refuse to close on work that isn't durable yet, record the deliverable on the tack route, hand off the retro, and report the commands still owed rather than sequencing them. Triggers on \"wrap up\", \"all done\", \"close this out\"."
+argument-hint: "[repo-name] [abandoned: reason]"
+---
+
+# End
+
+Close the session `/tack:start` opened. Read the end state from live signals,
+hold the session to a durable artifact, record what landed on the tack route,
+hand off the retro, and hand back the list of commands still owed.
+
+**The line this skill does not cross:** it never launches a commit, a review, a
+merge, or a release on its own initiative. Timing and sequencing belong to the
+user, who can see the same state this skill reports. Naming the next command is
+the deliverable; deciding when to run it is not. The one thing it does insist on
+is the durability floor in step 2, and there it *asks*.
+
+**Name only commands the session actually has.** The `next` column below is
+written against `/anchor:*`, which is where those operations live when anchor is
+installed. Read the available-skills listing; with anchor absent, name the raw
+`gh`, `glab`, and `git` equivalents instead. A named command that doesn't
+resolve is worse than no name.
+
+The same holds for every optional companion this skill reaches for: when one
+isn't there, drop the step and **say which step was dropped** in the footer.
+Skipping silently is what makes a thinner close look like a complete one.
+
+**One output, at the end.** Steps 1–4 run silently: no per-step narration, no
+interim findings, no announcing what is about to run. Step 5's table is the
+skill's entire user-facing result, and it has a fixed shape and a fixed budget.
+
+**Skip this when** the session opened no route and produced nothing to record, or
+when the user is mid-task and only wants a status read. A session whose work went
+nowhere is *not* a skip: it has bookkeeping of its own (step 2).
+
+## 1. Read the end state
+
+Read every signal fresh. The draft flag and the pipeline both flip live, and a
+value carried over from earlier in the session is the one most likely to be
+wrong.
+
+**Issue these as parallel calls in one message.** Every read is independent, and
+running them one per turn is most of what makes this skill slow.
+
+```bash
+git status --short
+git log --oneline '@{upstream}..HEAD'    # single-quoted: @{…} trips the bash gate bare
+gh pr view --json number,isDraft,mergeable,statusCheckRollup,reviewDecision
+glab mr view --output json               # GitLab equivalent of the line above
+tack status {slug}
+```
+
+**A pushed branch with an open draft CR and green checks is a stall, not a
+finish.** It is the state a session leaves behind when it runs
+`/anchor:prepare-review` and stops. Every visible signal reads as delivered:
+commit pushed, description written, checks passing, reviewer-ready. The one bit
+that says otherwise is the draft flag, and nothing downstream that tracks
+deliverables can see it. Name it in step 5's one sentence when it shows up
+(*"the ship stalled at the draft flag"*) — a sentence, not a paragraph.
+
+## 2. Hold the durability floor
+
+A session does not end on work that lives only in the working tree. The floor is
+a **durable artifact**, and step 1's read says which level the session reached:
+
+- **Minimum: a commit, pushed.** Off this machine, recoverable by someone else.
+- **Usual: a pushed branch with a draft CR.** What makes the work visible to a
+  reviewer, to anything reading routes, and to the next session that opens on
+  this route.
+- **Sometimes: released and verified.** When shipping was the session's point,
+  a merged CR with no release behind it is still short of the floor.
+
+Below the floor, **don't close**. Name the level the session is at, name the
+commands that reach the next one (step 5 has them), and ask whether to run them
+now. Asking is the whole mechanism: sequencing stays the user's, and a session
+that ends with its work uncommitted has produced nothing that survives it.
+
+Two states that read as done and are not: a clean `git status` with unpushed
+commits, and the draft-flag stall above. Both look finished from inside the
+session and leave nothing durable outside it.
+
+### The dead end is a real ending, and it has its own bookkeeping
+
+Some sessions produce nothing worth keeping: the approach was wrong, the premise
+dissolved, the work turned out to be already done upstream. That is a legitimate
+close, not a floor violation, and `/tack:end <reason>` is how it's declared. What
+it must not do is leave the route open and the branch dangling for a fleet view
+to report as live work.
+
+Ask for the reason if it wasn't given, then:
+
+- **Drop the tack and record why on the route.** The reason is the whole value of
+  a dead end, so it goes somewhere durable rather than dying with the session.
+
+  ```bash
+  tack drop {slug} t1
+  tack describe {slug} "Abandoned: <reason>. <what the next attempt should know>"
+  ```
+
+- **Decide the branch and the tree explicitly, and ask before discarding.** Work
+  worth re-reading later still wants a commit on the branch, dead end or not. Work
+  that is genuinely garbage can go, but that is the user's call, never an
+  assumption.
+- **Don't leave a `blocked` tack behind**, unlike the ordinary close: blocked
+  means someone is coming back to it.
+- **A dead end is often the more retro-worthy session.** The failed approach is
+  the finding, and it's the kind that gets rediscovered expensively. Hand step 4
+  the retro rather than skipping it because nothing shipped.
+
+## 3. Record what landed on the route
+
+This is the bookkeeping nothing else does, and skipping it is what makes a fleet
+view report a session that shipped as a session that stalled.
+
+```bash
+tack deliverable {slug} t1 "<merged CR or commit url>"   # label auto-derived
+tack done {slug} t1
+tack link add {slug} t1 "pipeline #3256652" "https://..."
+tack status set {slug} t1 blocked                        # when it's waiting on someone
+tack deliverable rm {slug} t1 --to-link                  # demote one recorded too early
+```
+
+Match the record to reality rather than to intent:
+
+- **A deliverable is a landed thing.** An open CR is a `link`; a merged CR or a
+  pushed commit is the `deliverable`. Recording an open CR as the deliverable
+  closes the route while the work is still out for review.
+- **Blocked beats done.** When the work waits on a reviewer, an approval gate, or
+  another team, `tack status set … blocked` records the reason the route stays
+  open. Silence reads as forgotten.
+- **A second deliverable earns a second tack**, added now (`tack add`), not
+  invented as a subdivision of the first.
+- **Repair a record that's already wrong.** The route may already carry a
+  deliverable written earlier in the session, when the CR looked finished and
+  hadn't been marked draft-ready yet. Step 1's fresh read is what exposes it, and
+  the fix is a demotion, not a note: `tack deliverable rm {slug} t1 --to-link`
+  keeps the URL as a link and reopens the route. Check the flag's own help before
+  reaching for it — `tack rename` takes two *route* slugs, and guessing an
+  argument order here renames the route out from under the session.
+
+## 4. Hand off the retro
+
+Run whatever retrospective skill the available-skills listing carries —
+`/logbook:retro` when logbook is installed — and let it decide whether the
+session earned one. It reads the session's own captured notes first, so
+re-deriving that judgment here would duplicate work that already happens
+downstream with better material.
+
+- **Don't recap the retro's material.** The worker reads this session's
+  transcript, so listing what it has material on is output the user pays for and
+  the worker never sees.
+- **Don't wait for the document.** A retro that spawns its own session returns
+  immediately; this session is closed regardless of what that one produces.
+- **The exception is a skill the Skill tool refuses** (`cannot be used with Skill
+  tool due to disable-model-invocation`). Then the user types it, and the seeds
+  go with the ask so the worker doesn't start cold — name the specific moments
+  worth a note, not the topic.
+
+Notes deferred by *earlier* sessions, where the retro tool reports them, are one
+`notes` line in step 5's block, not a paragraph of their own.
+
+**Set no session signal here.** The route's state, which step 3 just wrote, is
+what a fleet view reads to decide this session is done. Writing a separate status
+gives the same field a second source that goes stale the moment the route moves.
+
+## 5. Report what's still owed
+
+Close with one table in `/tack:start`'s shape — the state read in step 1 and the
+commands that advance it. This is the skill's whole output:
+
+```text
+| change | state | next |
+|---|---|---|
+| [cleat#3](https://…/pull/3) | draft · checks ✅ test, preview · `2ff4d9e` | `gh pr ready 3` → /code-review → /anchor:merge → /anchor:release |
+| [cleat#7](https://…/pull/7) | merged · `a91c204` | — |
+
+**route** cleat t5 open, #3 and the commit as links · **retro** launched in a new tab
+**notes** 3 sessions hold deferred notes — `/logbook:retro <id>`
+```
+
+- **Emit it as markdown, not inside a fence.** The example above is fenced so
+  its source is visible; what reaches the user is a rendered table with working
+  links. A fenced copy is the old text block with extra steps.
+- **One row per thing the user can act on** — a CR, a pushed commit, the working
+  tree when step 2's floor isn't met. A session with nothing to act on (a dead
+  end, a read-only close) drops the table and keeps the footer.
+- **`next` is commands in the order they run**, arrow-separated, no
+  explanations. Nothing left to run is `—`.
+- **The footer is `route`, `retro`, `notes`**, bold-labelled, one line each, and
+  any field with nothing to say is dropped — no empty `retro` line, no `notes`
+  line when there are none.
+- **Live links, not dead tokens.** The change cell carries a linked forge
+  reference (`cleat#3`, `ai-tools!23`), never a bare number or a raw URL, and
+  shas go in backticks at 7 characters. Name absent signals as absent (`no
+  checks`, never `green`).
+- **The columns hold the alignment, so nothing depends on padding.** The shape
+  this replaces was a space-aligned text block whose second repo wrapped out of
+  its column and whose forge references couldn't be clicked.
+- **Above the table, at most one sentence**, and only when step 1 found the draft
+  stall, step 2 found the floor unmet, or step 3 corrected a record. Otherwise
+  the table stands alone.
+- **Below it, at most one line per caveat** from the state table's two flagged
+  rows.
+- **No prose recap of what steps 1–4 did.** The wall of text this replaces is
+  the failure mode: the user reads the table, then acts.
+
+**This table has a second, earlier trigger.** The `landing-nudge` hook fires when
+a CR description is written — the first moment a session has something
+reviewable — and asks for a table in this shape right there. That preview is not
+the close: it reports where things stand and what runs next, while this skill
+still records the deliverable on the route (step 3) and hands off the retro
+(step 4). So a session that already emitted the preview does **not** skip this
+step; it re-reads the state and closes properly.
+
+| State | Next |
+|---|---|
+| Uncommitted changes in the tree | `/anchor:commit` |
+| Committed, not pushed | `git push` |
+| Pushed, no CR | `/anchor:prepare-review` |
+| CR still a draft | `gh pr ready <n>` / `glab mr update <n> --ready` |
+| No review pass on the changeset | `/code-review` |
+| Open review threads | `/anchor:resolve-feedback` |
+| Checks pending | `/anchor:pipeline --watch` |
+| `SPEC.md` present, ledger not refreshed | `/sextant:spec-status` — before the release, not trailing the CR |
+| Ready, green, approved | `/anchor:merge` |
+| Merged, repo publishes releases | `/anchor:release` — it owns the version bump; a hand-bump lands a conflicting commit |
+| Nothing left to run, floor cleared | say that in one line and stop |
+| Declared a dead end | nothing to run; the route carries the reason |
+
+## Multi-repo sessions
+
+`/tack:end <name>` resolves `<name>` to one repo by case-insensitive substring match
+against the basename of every git repo the session touched. One match: confirm it
+in one line and close against it. Zero or several: list the touched repos and
+ask. Without an argument the target is the cwd repo.
+
+When the session touched several repos, run steps 1, 2, 3, and 5 once per repo, then
+hand off the retro once for the whole session.
+
+## Related
+
+`/tack:start` opens what this closes. The end-state read exists because a session
+that *feels* shipped and a session whose draft flag is still set are
+indistinguishable without it — read the signals, don't recall them. Reporting
+owed commands rather than running them is what keeps the close inside the work
+the session actually did.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: start
+description: "Open a work session: read the linked issue or CR thread in full, derive one slug, cut the branch, and bind the tack route. Triggers on \"start work on <issue-url>\" or \"pick up #42\"."
+argument-hint: "[what] [issue-url]"
+---
+
+# Start
+
+Open a work session. One slug names the work, and the
+branch, the tack route, and the session label all agree on it. Whatever playbook
+follows assumes this ran: without it the branch answers to no route, nothing that
+reads routes can see the work, and the linked ticket goes unread.
+
+**Skip this when** a route already resolves for the session (the gate below),
+when the ask is a question or a read-only investigation with no deliverable, or
+when work is already underway on a named branch and only the thread reading is
+wanted.
+
+## Gate: is a session already open here?
+
+Every prompt carries tack's own resolution line, injected by its
+`UserPromptSubmit` hook. Read it before running anything:
+
+- **A route resolves** (by cwd pin or branch-slug match). The session is open.
+  Report it in one line and stop. A second route over work already tracked is
+  what makes every reader of those routes double-count it.
+- **No route resolves** (`no pin, no branch-slug match`). Continue below.
+
+When that line isn't in context, probe instead: `tack pin` prints the cwd pin
+and exits 1 with `no pin set for current directory` when there is none, and
+`tack status <branch>` exits 1 with `Route not found` when the branch matches no
+route.
+
+## Read the linked artifact in full
+
+When the arguments carry a URL, that URL is the session's brief. Read the whole
+artifact before anything else, and read it as a document rather than as a
+lookup:
+
+- **Fetch the description *and* every note or comment**, in chronological order
+  (`glab api "projects/<path>/merge_requests/<n>/notes?per_page=100"`,
+  `gh pr view <n> --comments`). One call returns the thread; read what it
+  returns.
+- **A fragment anchors a position, not a scope.** `#note_<id>`,
+  `#issuecomment-<id>`, and line anchors point at where the conversation was
+  when the link was copied. Never filter the fetched thread down to the anchored
+  id: the surrounding notes are why the link was shared.
+- **The user's own replies are constraints, not commentary.** A thread the user
+  participated in usually already settles scope, contract, and versioning
+  questions. Treat what they wrote there as decided.
+- **State back what the thread settled** before proposing anything: who
+  reported what, which approach was rejected and why, and any decision already
+  made. If a later step is about to contradict one of those, surface the
+  conflict instead of re-deciding it.
+
+Skipping this is the most expensive mistake this skill can make: a fix that
+lands in minutes gets re-litigated for an hour against a position the user
+already stated in writing.
+
+## Derive one slug
+
+`${CLAUDE_PLUGIN_ROOT}/skills/start/scripts/parse-start-args.py` owns the
+deterministic half. It recognizes GitLab
+issue and MR URLs and GitHub issue and PR URLs, returning the `repo`, the
+numeric id, and the reference notation (`#` for issues and GitHub PRs, `!` for
+GitLab MRs); it exits non-zero on an unrecognized URL rather than guessing. It
+also slugifies a `--hint` string with fixed rules (lowercase, non-alphanumerics
+to hyphens, collapse, strip, truncate at 60).
+
+The judgment stays here: which text becomes the slug. Pick the source by
+priority:
+
+1. **User-provided text** beyond the URL (the prompt text alongside the command,
+   or the working directory name).
+2. **The issue or CR title**, fetched when a URL was given (`glab api` for
+   GitLab, `gh issue view` for GitHub).
+3. **Ask**, when there is no text hint, no URL, and the cwd name is too generic
+   to name the work.
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/start/scripts/parse-start-args.py" \
+  "https://gitlab.example.com/group/repo/-/issues/42" --hint "Fix the Select bug"
+# -> repo=repo  ref_type=issue  number=42  prefix=#  ref=#42  slug=fix-the-select-bug
+```
+
+## Bind the slug
+
+**1. The branch.** Switch to `{slug}` if it exists, otherwise cut it from the
+freshly fetched default branch — never from whatever happens to be checked out:
+
+```bash
+git fetch origin {default}
+git checkout -b {slug} --no-track origin/{default}
+```
+
+**Don't drop `--no-track`.** Without it the new branch takes
+`origin/{default}` as its upstream, and the first plain `git push` refuses:
+*"The upstream branch of your current branch does not match the name of your
+current branch."* The branch wants no upstream until its own first push sets
+one.
+
+`{default}` is the repo's default branch, which
+`git symbolic-ref --short refs/remotes/origin/HEAD` resolves. Whichever branch
+the checkout was parked on belongs to whatever ran here last; branching off it
+stacks this work on a base it has no relationship to, and the dependency only
+surfaces at review. Stack deliberately — `git checkout -b {slug}` off the
+current branch — when the user says this work builds on it, and say that you
+did.
+
+Uncommitted work in the tree carries over to the new branch. When the tree is
+dirty with changes that belong somewhere else, say so and ask before branching.
+
+**When another live session already holds this checkout**, one tree can't serve
+both: its index and HEAD are shared, so each session's commits sweep up the
+other's in-flight files. The `checkout-collision` hook names the occupants on
+the first prompt. Give this work its own tree with `EnterWorktree {slug}`, which
+switches this session into it and branches from the default branch by default
+(`worktree.baseRef: fresh`), so step 1's base is handled.
+
+Tell the user you did, and what it means for them: which sessions hold the
+original checkout, and the path and branch this session now works in. They are
+steering several windows, and one of them silently changing directory is its own
+way to lose track of work. `ExitWorktree` is theirs to ask for, not yours to
+call — Claude Code prompts to keep or remove the tree when the session ends.
+
+**2. The tack route.** The route persists across conversations and is the source
+of truth for work-in-progress state that `/tack:end` and every fleet reader work
+from. Create it and link the brief:
+
+```bash
+tack init {slug}
+tack add {slug} "Initial implementation"
+tack link add {slug} t1 "{repo} {ref}" "{issue_url}"
+```
+
+Omit the `tack link add` when no URL was given.
+
+**Don't run `tack session`.** The `session-nudge` hook binds the session to the
+route from its own stdin, which is the only place the session id is reliably
+available — `$CLAUDE_SESSION_ID` is not exported to the shell. Creating the route
+here is what lets the hook resolve it by branch-slug match on the next prompt.
+
+Branch-slug match is what resolves the route on later turns, so a branch named
+for the slug needs no pin. **Pin only when the branch can't carry the slug**:
+work staying on the default branch, or a worktree whose branch is named
+something else.
+
+```bash
+tack pin {slug}
+```
+
+**Don't set a session label.** A bound route is what a fleet view reads to label
+the session, so writing one separately gives it a second, staler source for the
+same field.
+
+## Report, then hand off
+
+Close with the session's state in one table and the command the work continues under.
+Name the skill; don't invoke it — which playbook fits is the user's call:
+
+```text
+| field | value |
+|---|---|
+| brief | [#42](https://…/issues/42) Select drops the second value — 4 notes, scope settled |
+| branch | `fix-the-select-bug` (new) |
+| route | `fix-the-select-bug t1` |
+| next | `/fix` |
+```
+
+The example is fenced so its source is visible; emit the table as markdown, not
+inside a fence, so the links work. `/end` closes on a table in the same shape,
+so the open and the close read as a pair and `next` means the same thing in both. The
+brief's forge reference is a live link, never a bare number or a raw URL.
+
+**`next` names a playbook the session actually has.** Resolve it from the
+available-skills listing rather than a fixed name: a defect with an unknown cause
+wants a diagnosis skill, new capability on an existing codebase wants an
+implementation one. `git config tack.handoff` overrides the choice where a repo
+always opens the same way. With nothing suitable in the listing, drop the row —
+a named command that doesn't resolve is worse than no row. The `/fix` above is
+illustrative. Where a row is dropped for that reason, say so in the sentence
+above the table rather than leaving a thinner open looking complete.
+
+With no URL there is no brief row; say what the work is in one sentence above the
+table instead.
+
+## Keep the route current while the session runs
+
+- **Links, as they appear.** Attach URLs to the tack when they first surface
+  rather than waiting to be asked. Typical triggers: the user pastes a URL,
+  `git push` prints an MR URL, a pipeline gets referenced.
+
+  ```bash
+  tack link add {slug} t1 "pipeline #3256652" "https://..."
+  ```
+
+- **Tacks, only for discrete deliverables.** Never add one speculatively. A
+  second tack means a second committed deliverable (a separate PR or MR); most
+  sessions produce one.
+
+`/tack:end` reads this state to decide what actually landed, so a route left
+empty makes the close guess.
+
+## Related
+
+`/tack:end` closes what this opens. `/tack:tack` owns route resolution for a
+session that never ran this — note that `tack start` is a CLI subcommand that
+moves a tack to `in_progress`, a different thing from this skill.

--- a/skills/start/scripts/parse-start-args.py
+++ b/skills/start/scripts/parse-start-args.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Parse a /start issue/MR URL and slugify a label — the deterministic half of
+session setup, extracted from prose so the agent doesn't re-derive URL parsing
+and slug rules on every invocation (per the "Script for Repeatability" pattern).
+
+Usage:
+    parse-start-args.py [URL] [--hint TEXT]
+
+Prints key=value lines on stdout. Keys that don't apply are omitted:
+    repo=<repository name>
+    ref_type=<issue|mr|pull>
+    number=<numeric id>
+    prefix=<# or !>     # the reference notation for {prefix}{N}
+    ref=<prefix><number>
+    slug=<slugified --hint, if given>
+
+The side-effectful steps (beacon, git branch, tack) stay in the skill — they
+need agent judgment and are simple command sequences, not parsing logic.
+"""
+import re
+import sys
+
+
+def slugify(text: str, max_len: int = 60) -> str:
+    """lowercase; non-alphanumerics -> hyphens; collapse; strip; truncate."""
+    s = re.sub(r"[^a-z0-9]+", "-", text.lower())
+    s = re.sub(r"-{2,}", "-", s).strip("-")
+    if len(s) > max_len:
+        s = s[:max_len].rstrip("-")
+    return s
+
+
+# (regex, ref_type, prefix). GitLab issues use #, MRs use !; GitHub uses # for both.
+URL_PATTERNS = [
+    (re.compile(r"https?://[^/]+/(?:.+/)?(?P<repo>[^/]+)/-/issues/(?P<number>\d+)"), "issue", "#"),
+    (re.compile(r"https?://[^/]+/(?:.+/)?(?P<repo>[^/]+)/-/merge_requests/(?P<number>\d+)"), "mr", "!"),
+    (re.compile(r"https?://github\.com/[^/]+/(?P<repo>[^/]+)/issues/(?P<number>\d+)"), "issue", "#"),
+    (re.compile(r"https?://github\.com/[^/]+/(?P<repo>[^/]+)/pull/(?P<number>\d+)"), "pull", "#"),
+]
+
+
+def parse_url(url: str):
+    for pattern, ref_type, prefix in URL_PATTERNS:
+        m = pattern.match(url)
+        if m:
+            return {
+                "repo": m.group("repo"),
+                "ref_type": ref_type,
+                "number": m.group("number"),
+                "prefix": prefix,
+                "ref": f"{prefix}{m.group('number')}",
+            }
+    return None
+
+
+def main(argv):
+    url = None
+    hint = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--hint":
+            hint = argv[i + 1] if i + 1 < len(argv) else ""
+            i += 2
+            continue
+        if arg.startswith("http://") or arg.startswith("https://"):
+            url = arg
+        i += 1
+
+    out = {}
+    if url:
+        parsed = parse_url(url)
+        if parsed is None:
+            print(f"error=unrecognized URL: {url}", file=sys.stderr)
+            return 1
+        out.update(parsed)
+    if hint:
+        out["slug"] = slugify(hint)
+
+    for key in ("repo", "ref_type", "number", "prefix", "ref", "slug"):
+        if key in out:
+            print(f"{key}={out[key]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/tack/SKILL.md
+++ b/skills/tack/SKILL.md
@@ -2,10 +2,10 @@
 name: tack
 description: >
   Track AI-assisted development work with the `tack` route tracker, spanning
-  session boundaries. This skill should be used at session start to answer
-  "what am I working on?" and load context on current work, and when the user
-  refers to tack routes, tacks, or recording a PR/MR deliverable against
-  tracked work.
+  session boundaries. This skill should be used to answer "what am I working
+  on?" and load context on current work, and when the user refers to tack
+  routes, tacks, or recording a PR/MR deliverable against tracked work.
+  Opening and closing a session belong to the start and end skills.
 argument-hint: "[command]"
 ---
 

--- a/spec/v1/SPEC.md
+++ b/spec/v1/SPEC.md
@@ -217,12 +217,12 @@ and still produces the usual "tack not found" error.
 
 ---
 
-### DEL — Deliverable
+### DELIVER — Deliverable
 
-**[DEL-01]** Each tack shall have at most one deliverable. The deliverable
+**[DELIVER-01]** Each tack shall have at most one deliverable. The deliverable
 represents the change request (PR/MR) that the tack produces.
 
-**[DEL-02]** Each deliverable shall contain the following required fields:
+**[DELIVER-02]** Each deliverable shall contain the following required fields:
 - `label` (string) — short display text
 - `url` (string) — full URL
 
@@ -253,28 +253,28 @@ for that array's prefix.
 
 ---
 
-### DEP — Dependencies
+### DEPENDS — Dependencies
 
-**[DEP-01]** Route-level `depends_on` shall be an array of route slugs
+**[DEPENDS-01]** Route-level `depends_on` shall be an array of route slugs
 (strings).
 
-**[DEP-02]** Tack-level `depends_on` shall be an array of tack IDs within the
+**[DEPENDS-02]** Tack-level `depends_on` shall be an array of tack IDs within the
 same route.
 
-**[DEP-03]** When a tack has `depends_on` entries and any referenced tack has a
+**[DEPENDS-03]** When a tack has `depends_on` entries and any referenced tack has a
 status other than `done`, the dependent tack's status shall not be set to
 `in_progress` — the operation shall fail with an error indicating which
 dependencies are unmet.
 
-**[DEP-04]** Route-level dependencies shall be informational. The CLI shall
+**[DEPENDS-04]** Route-level dependencies shall be informational. The CLI shall
 display them in `tack status` output but shall not enforce them (the referenced
 route files may not exist locally).
 
 ---
 
-### LINK — Links
+### LINKS — Links
 
-**[LINK-01]** Each link shall contain the following required fields:
+**[LINKS-01]** Each link shall contain the following required fields:
 - `label` (string) — short display text
 - `url` (string) — full URL
 
@@ -397,7 +397,7 @@ tack created in error, use [CLI-25].
 
 **[CLI-07]** `tack start <slug> <tack-id>` — When invoked, the CLI shall set
 the specified tack's status to `in_progress`. If the tack has `depends_on`
-entries with unmet dependencies, the operation shall fail per [DEP-03]. The
+entries with unmet dependencies, the operation shall fail per [DEPENDS-03]. The
 error message shall guide the user to either drop the edge with
 [CLI-33] (`tack depends rm`) when the declared ordering no longer holds, or
 to bypass the guard with [CLI-34] (`tack status set`) when the inconsistent
@@ -618,7 +618,7 @@ the array becomes empty, the field shall be omitted from the YAML. If
 **[CLI-34]** `tack status set <slug> <tack-id> <status>` — When invoked, the
 CLI shall set the specified tack's `status` field to the given value
 (`pending`, `in_progress`, `done`, `blocked`, or `dropped`) without enforcing
-[DEP-03] dependency guards. When the new status is `done` and `done_at` is
+[DEPENDS-03] dependency guards. When the new status is `done` and `done_at` is
 not already set, the CLI shall stamp `done_at` per [TACK-03]. This command is
 the supported escape hatch for representing states the guarded commands
 ([CLI-05], [CLI-06], [CLI-07]) refuse to produce (e.g., reverting a `done` tack
@@ -629,7 +629,7 @@ shall rename the route file from `<old-slug>.yaml` to `<new-slug>.yaml` and
 update the `slug` field inside the file. The route's `id` ([ROUTE-08]) shall
 be preserved. The CLI shall fail if `<new-slug>` already exists as a route,
 if `<old-slug>` does not exist, or if any other route's `depends_on`
-references `<old-slug>` (per [DEP-01]).
+references `<old-slug>` (per [DEPENDS-01]).
 
 **[CLI-36]** `tack move <src-slug>/<tack-id> <dst-slug> [--include-dependents]`
 — When invoked, the CLI shall remove the specified tack from the source
@@ -677,7 +677,7 @@ label derivation ([CLI-04], [CLI-08]), producing `<group>&<n>` and `<repo>%<n>`
 respectively — GitLab's own reference syntax. Neither is a change request: they
 shall not be promoted to a deliverable on `tack done` ([CLI-05]). Both shall be
 surfaced by the hook scanners ([HOOK-02], [HOOK-03]), which nudge the agent to
-record them as links ([AGT-06]). Neither shall contribute an entry to the repo
+record them as links ([AGENT-06]). Neither shall contribute an entry to the repo
 database ([REPO-06]): both can be group-scoped, where the path carries a group
 rather than a repo.
 
@@ -822,7 +822,7 @@ markdown horizontal rule, since the merge deletes the source files and a body
 left behind would be unrecoverable.
 
 **[CLI-52d]** When a route outside the merge set has a route-level `depends_on`
-([DEP-01]) referencing a source route, the CLI shall refuse the merge to avoid
+([DEPENDS-01]) referencing a source route, the CLI shall refuse the merge to avoid
 dangling the reference, unless `--break-deps` is passed, which repoints those
 references at `<new-slug>`.
 
@@ -877,21 +877,21 @@ skipped tack is indistinguishable from one that hasn't merged.
 
 ---
 
-### AGT — Agent Integration
+### AGENT — Agent Integration
 
 The CLI encapsulates schema operations; the skill encapsulates reasoning.
 Inference (what's active, which route to attach to, when to prompt) lives in
 the skill and uses CLI primitives. Hooks emit reminders (see HK); the skill
 acts on them.
 
-**[AGT-01]** The agent shall be implemented as a Claude Code skill that reads
+**[AGENT-01]** The agent shall be implemented as a Claude Code skill that reads
 and writes tack route files using the CLI defined in the CLI category.
 
-**[AGT-02]** When a session begins, the plugin's skill shall load all active
+**[AGENT-02]** When a session begins, the plugin's skill shall load all active
 routes (routes with at least one tack whose status is not `done` or `dropped`)
 to build context about current work.
 
-**[AGT-03]** The agent shall maintain the answer to "what am I working on?"
+**[AGENT-03]** The agent shall maintain the answer to "what am I working on?"
 for the current working directory by running the following resolution
 procedure in order, stopping at the first confident match:
 
@@ -901,7 +901,7 @@ procedure in order, stopping at the first confident match:
 2. **URL match** — When a PR/MR/issue URL is in scope (recently emitted by
    a tool, pasted by the user, or passed as a hint), run `tack find --url
    <url> --json` and use the matched route if exactly one is returned. The matched
-   tack is also the session's tack per [AGT-11] — bind it via [AGT-09].
+   tack is also the session's tack per [AGENT-11] — bind it via [AGENT-09].
 3. **Branch slug** — When the cwd is a git repository, run `tack list
    --json` and use the route whose slug equals the current branch name if
    it has at least one open tack.
@@ -909,48 +909,48 @@ procedure in order, stopping at the first confident match:
 5. **Ambiguous or unknown** — Prompt the user via `AskUserQuestion` with
    candidates: in-progress routes, recently-updated routes (via `tack
    recent --json`), or a "start a new route" option. On the user's pick,
-   record the answer with `tack pin <slug>` per [AGT-10].
+   record the answer with `tack pin <slug>` per [AGENT-10].
 
-**[AGT-04]** When the user confirms a new route during resolution per [AGT-03],
+**[AGENT-04]** When the user confirms a new route during resolution per [AGENT-03],
 the agent shall run `tack init <slug>` and add the first tack with `tack add`.
 
-**[AGT-05]** When a hook emits a deliverable reminder per [HOOK-02], or a PR/MR
+**[AGENT-05]** When a hook emits a deliverable reminder per [HOOK-02], or a PR/MR
 URL otherwise appears in the session, the agent shall record the URL on the
 active route's current tack via `tack deliverable <slug> <tack-id> <label>
 <url>` without prompting the user. If no active tack exists, the agent shall
 add one with `tack add` and then record the deliverable.
 
-**[AGT-06]** When a hook emits a link reminder per [HOOK-02], or a non-PR/MR
+**[AGENT-06]** When a hook emits a link reminder per [HOOK-02], or a non-PR/MR
 URL is referenced in the session, the agent shall capture it via `tack link
 add <slug> <tack-id> <label> <url>` on the active tack. URLs already recorded
-as a deliverable per [AGT-05] shall not be duplicated; the CLI enforces this
+as a deliverable per [AGENT-05] shall not be duplicated; the CLI enforces this
 per [CLI-13].
 
-**[AGT-07]** The agent shall not prompt the user more than once per distinct
+**[AGENT-07]** The agent shall not prompt the user more than once per distinct
 event. If the user ignores or dismisses a prompt, the agent shall not re-ask
 about the same work item in the same session.
 
-**[AGT-08]** When the user completes a tack, the agent shall surface any
+**[AGENT-08]** When the user completes a tack, the agent shall surface any
 pending `after` todo items per [TACK-04] before moving on.
 
-**[AGT-09]** When the agent begins operating on a route, it shall record the
+**[AGENT-09]** When the agent begins operating on a route, it shall record the
 current Claude Code session ID in the route's `sessions` array per [ROUTE-09].
 If the session ID already exists, it shall not duplicate. When the agent has
-resolved which tack the session is working — a tack matched per [AGT-11], the
+resolved which tack the session is working — a tack matched per [AGENT-11], the
 single open tack, or one the agent created for this session — it shall pass
 `--tack <tack-id>` to bind the session to that tack per [ROUTE-11], and re-bind
 when the session's focus shifts to a different tack.
 
-**[AGT-11]** The agent shall establish the session→tack link as early as it
+**[AGENT-11]** The agent shall establish the session→tack link as early as it
 confidently can, so a fleet view can distinguish *existing* work (a session
 resumed on tracked work) from *emerging* work (a session that spun up a new
 tack). When a PR/MR/issue/tracker URL is in scope at session start (pasted by
 the user, passed as a hint, or emitted by a tool per [HOOK-02]/[HOOK-03]), the
 agent shall run `tack find --url <url> --json` per [CLI-23]:
 - **Match** — exactly one tack references the URL: the session is resuming
-  existing work. The agent shall bind the session to that tack per [AGT-09].
+  existing work. The agent shall bind the session to that tack per [AGENT-09].
 - **No match** — the work is emerging. The agent shall create a tack per
-  [AGT-04]/[AGT-05] (recording the URL as its deliverable or link) and bind the
+  [AGENT-04]/[AGENT-05] (recording the URL as its deliverable or link) and bind the
   session to the new tack.
 
 The existing-vs-emerging distinction is not stored as a flag; a consumer
@@ -958,7 +958,7 @@ derives it from the bound tack's own state — a tack carrying a deliverable or
 a PR/MR/issue link ([CLI-37]) is tracked/existing, one with neither is
 emerging.
 
-**[AGT-10]** When the agent resolves an active route via [AGT-03] in a way
+**[AGENT-10]** When the agent resolves an active route via [AGENT-03] in a way
 that is not already pinned (URL match, branch slug, single-open-route, or
 user pick), the agent shall pin the result with `tack pin <slug>` so future
 resolutions are immediate. The agent shall not pin speculatively — only
@@ -974,7 +974,7 @@ Hooks are scaffolding around the agent. They surface signals the agent might
 otherwise miss (URLs in tool output, URLs in user prompts, version drift),
 and they emit reminder text the agent reads as additional context. Hooks
 never write to route files directly; the skill performs all writes via the
-CLI per [AGT-05] and [AGT-06].
+CLI per [AGENT-05] and [AGENT-06].
 
 **[HOOK-01]** A `SessionStart` hook shall compare the installed CLI wrapper's
 version to the plugin's `version` per [CLI-29]. When they differ, the hook
@@ -988,8 +988,8 @@ output for PR/MR and issue URLs (the recognized forges are defined in
 tracks the URL by running `tack find --url <url>` ([CLI-23]); a URL already mapped
 emits no reminder, so the hooks stop nagging about work that is already
 recorded. Only an untracked URL shall emit reminder text, instructing the
-agent to ensure a route/tack mapping exists via the tack skill per [AGT-05] or
-[AGT-06] depending on URL type. When `tack` is not on `PATH` the tracked-check
+agent to ensure a route/tack mapping exists via the tack skill per [AGENT-05] or
+[AGENT-06] depending on URL type. When `tack` is not on `PATH` the tracked-check
 cannot run, so the hook shall emit the reminder unconditionally.
 
 **[HOOK-03]** A `UserPromptSubmit` hook shall scan the user's prompt for
@@ -998,16 +998,25 @@ PR/MR and issue URLs ([CLI-37]) and emit the same kind of reminder as
 hook is responsible for noticing URLs the user pastes inline rather than
 through a Bash tool call.
 
-**[HOOK-04]** The `UserPromptSubmit` hook shall also, once per session, resolve
-the route for the current cwd by running [AGT-03] step 1 (pin for cwd, via
-`tack pin`) and step 3 (branch-slug route) — existence-only, without verifying
-the route's open-tack state and without prompting the user. When a route
-resolves, the hook shall record the current session on it per [ROUTE-09]
-(route-level, no tack binding), so session→route attribution does not depend on
-the agent remembering to run `tack session`. When neither resolves, the hook
-shall emit a one-line nudge suggesting the user invoke the tack skill to
-identify or create a route. The hook shall debounce so this fires at most once
-per session.
+**[HOOK-04]** The `UserPromptSubmit` hook shall also resolve the route for the
+current cwd by running [AGENT-03] step 1 (pin for cwd, via `tack pin`) and step 3
+(branch-slug route) — existence-only, without verifying the route's open-tack
+state and without prompting the user. When a route resolves, the hook shall
+record the current session on it per [ROUTE-09] (route-level, no tack binding),
+so session→route attribution does not depend on the agent remembering to run
+`tack session`.
+
+**[HOOK-04a]** Resolution per [HOOK-04] shall repeat on every prompt until it
+binds, rather than running once per session. A session opened with the `start`
+skill has no route at its first prompt — the skill creates one mid-turn — so a
+once-per-session probe would look before the route exists and never look again,
+leaving the session unattributed for its whole life.
+
+**[HOOK-04b]** When no route resolves, the hook shall emit a nudge naming the
+`start` skill as the way to open one, at most once per session. The nudge shall
+be suppressed when the prompt already invokes that skill, and when the cwd is
+not a git repository. The once-per-session debounce applies to the nudge text
+only, never to the resolution of [HOOK-04a].
 
 **[HOOK-05]** Hook reminders are advisory: the *judgment-laden* writes — which
 slug and tack a URL maps to — shall be made by the agent via the tack skill,
@@ -1015,6 +1024,135 @@ not by the hook, so that context the hook cannot see is applied and those
 schema writes go through one path. The hook may perform deterministic reads
 (the `tack find` tracked-check per [HOOK-02]) and the route-level session record
 per [HOOK-04], which need no such judgment.
+
+**[HOOK-06]** A `PostToolUse` hook scoped to the `Bash` tool shall detect a
+change-request description being written — `gh pr … --body-file` on GitHub, a
+`merge_requests` call carrying `description=@` on GitLab — and emit reminder
+text asking for the handoff report of [SESSION-08]. The hook shall fire at most once
+per session, and only when the detection matched, so a session that revises a
+description twice is still at one handoff point. The reminder shall state that
+it previews the close rather than performing it.
+
+---
+
+### SESSION — Opening and Closing a Session
+
+Two skills bracket a session's work on a route: `start` binds one slug to a
+branch and a route, `end` reads what landed and records it. Both are skill-layer
+artifacts. They read git and forge state, which the CLI and schema never do, and
+nothing they read enters a route except through the CLI primitives already
+specified in the CLI category.
+
+**[SESSION-01]** The plugin shall provide a `start` skill that opens a work session
+by deriving one slug, cutting the branch that carries it, and creating the route
+the work is recorded against.
+
+**[SESSION-02]** Before doing anything else, the `start` skill shall check whether a
+route already resolves for the session per [HOOK-04]. When one does, the skill
+shall report it in one line and stop, so a second route is never opened over work
+already tracked.
+
+**[SESSION-03]** The `start` skill shall derive the slug from, in order of
+precedence: user-provided text, the title of a linked issue or change request,
+or a question to the user. Deterministic URL parsing and slugification shall be
+performed by a bundled script rather than re-derived per invocation.
+
+**[SESSION-04]** The `start` skill shall cut the work's branch from the freshly
+fetched default branch rather than from whatever is checked out, except where
+the user states the work builds on the current branch.
+
+**[SESSION-05]** The `start` skill shall not run `tack session`. Session binding is
+the hook's responsibility per [HOOK-04], which is the only place the session id
+is reliably available.
+
+**[SESSION-06]** The plugin shall provide an `end` skill that closes a work session
+by reading the end state fresh, holding the durability floor of the FLOOR
+category, recording what landed on the route, and reporting the commands still
+owed.
+
+**[SESSION-07]** The `end` skill shall not launch a commit, a review, a merge, or a
+release on its own initiative. Naming the next command is its deliverable;
+sequencing is the user's.
+
+**[SESSION-08]** The `end` skill's entire user-facing output shall be one table of
+`change | state | next` rows plus a `route` / `retro` / `notes` footer, emitted
+as rendered markdown with live forge links. Steps preceding it shall run without
+narration.
+
+**[SESSION-09]** A session that produced nothing worth keeping is a legitimate close.
+The `end` skill shall drop the tack, record the reason on the route via `tack
+describe`, and decide the branch and working tree explicitly with the user rather
+than discarding either by assumption.
+
+**[SESSION-10]** Neither skill shall write a session label or status to any external
+fleet view. The route's own state is what a fleet view reads; a separately
+written label is a second source for the same field that goes stale when the
+route moves.
+
+---
+
+### BRIEF — Reading the Linked Artifact
+
+**[BRIEF-01]** Where the `start` skill is given a URL, that URL is the session's
+brief, and the skill shall read it before proposing anything.
+
+**[BRIEF-02]** The skill shall fetch the artifact's description *and* every note
+or comment on it, in chronological order.
+
+**[BRIEF-03]** A URL fragment identifying a single note or line shall be treated
+as anchoring a position, not as scoping the read. The skill shall never filter
+the fetched thread down to the anchored id.
+
+**[BRIEF-04]** The skill shall state back what the thread settled — who reported
+what, which approach was rejected, and any decision already made — before
+proposing work. Where a later step would contradict one of those, the skill
+shall surface the conflict rather than re-deciding it.
+
+---
+
+### DURABILITY — The Floor a Session Must Clear
+
+**[DURABILITY-01]** The `end` skill shall not close a session whose work exists only
+in the working tree. The floor is a durable artifact at one of three levels: a
+pushed commit (minimum), a pushed branch with a draft change request (usual), or
+a verified release (where shipping was the session's point).
+
+**[DURABILITY-02]** Below the floor, the skill shall name the level reached, name the
+commands that reach the next one, and **ask** whether to run them. It shall never
+block a status transition the CLI allows.
+
+**[DURABILITY-03]** The skill shall treat a pushed branch with an open *draft* change
+request and passing checks as a stall rather than a finish, and shall name the
+draft flag when it finds one — every other visible signal reads as delivered.
+
+**[DURABILITY-04]** A dead end declared per [SESSION-09] is not a floor violation.
+
+---
+
+### FALLBACK — Absent Companions
+
+The `start` and `end` skills name and read tools that are not tack. Every one of them
+is optional, and tack declares no runtime dependency on any plugin.
+
+**[FALLBACK-01]** Where a companion plugin's skill would be invoked or named, the
+skills shall determine its availability by reading the agent's own
+available-skills listing rather than probing the filesystem, since a plugin
+present on disk may be disabled.
+
+**[FALLBACK-02]** Where no forge-operation skill is available, the `end` skill shall
+name the equivalent `gh`, `glab`, and `git` commands instead. A named command
+that does not resolve for the session shall not be emitted.
+
+**[FALLBACK-03]** Where no retrospective skill is available, the `end` skill shall
+omit the retro handoff and its footer field rather than failing.
+
+**[FALLBACK-04]** Where no playbook fits the work in the available-skills listing, the
+`start` skill shall omit the handoff row rather than naming a command that does
+not resolve. A `tack.handoff` git-config value, where set, shall override the
+choice.
+
+**[FALLBACK-05]** No skill shall fail, and none shall silently continue, when an
+optional companion is absent: each shall complete and state what it skipped.
 
 ---
 
@@ -1262,10 +1400,15 @@ The following are explicitly out of scope:
 
 - **No project management.** No sprints, epics, story points, or velocity.
 - **No time tracking.** No start times, durations, or estimates.
-- **No git operations.** tack does not create branches, commits, or tags.
+- **No git operations in the CLI or schema.** The CLI creates no branches,
+  commits, or tags, and nothing git-derived is stored in a route. The Claude
+  Code skill layer reads git state and cuts the branch a route is named for,
+  which is an integration concern in the same sense as the rest of the plugin.
 - **No enforced workflows.** No prescribed state machines beyond the status
   enum. Users can move between statuses freely (except where dependencies
-  constrain transitions per [DEP-03]).
+  constrain transitions per [DEPENDS-03]). Where the skill layer holds a durability
+  floor before closing a route, it asks; it never blocks a transition the CLI
+  allows.
 - **No sync, no cloud, no non-loopback bind.** Local files are the only store.
   Two commands are allowed out of that shell and no more: `tack reconcile`
   ([CLI-56]) asks a forge a question the local files cannot answer, and
@@ -1274,4 +1417,4 @@ The following are explicitly out of scope:
   command wide by design, so nothing else grows a network dependency by
   drifting into it.
 - **No cross-route dependency enforcement.** Route-level `depends_on` is
-  informational only per [DEP-04].
+  informational only per [DEPENDS-04].


### PR DESCRIPTION
## Context

tack tracks *routes* — a named line of work, its tacks, and the change request each one produces — and it survives session boundaries, which is the whole point. What it never had was a defined start or finish. You created a route by hand when you remembered to, and closed it when you remembered to, so the two moments a route is most worth recording were the two the tooling said nothing about.

This adds the pair of skills that bracket a session's work on a route. `start` reads a linked issue or change request in full, derives one slug, cuts the branch, and creates the route. `end` reads git and forge state fresh, refuses to close on work that only exists in a working tree, records the deliverable, and reports the commands still owed without running any of them. Both have been in daily use in a private toolkit; this is them written down against a spec.

## Review guide

**Read first — the two new skills.** They're prose, so read them as instructions, not code.

- [`skills/start/SKILL.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-fbba5ae9c49f7e829a73947e305612326c8a8acd82d4a6ca8fe4f9b45026de5dR34) — reading the linked artifact *in full*. The rule that a URL fragment anchors a position rather than scoping the read is the part that earns its words; filtering a thread down to the anchored note is how a settled decision gets re-litigated.
- [`skills/start/SKILL.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-fbba5ae9c49f7e829a73947e305612326c8a8acd82d4a6ca8fe4f9b45026de5dR19) — the gate. `start` stops when a route already resolves, so a second route never opens over tracked work.
- [`skills/end/SKILL.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-952f413c6194ee0ff5c617cc38396b3b122477bbb09ec0d6b3f9d06147f7c142R62) — the durability floor. It asks, never blocks. A pushed branch with an open draft CR and green checks reads as delivered from every visible signal except the draft flag, so it's called out as a stall rather than a finish.

**The identity question — worth your judgment.**

- [`spec/v1/SPEC.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1403) — both anti-requirements now say which layer they bind. *"No git operations"* and *"no enforced workflows"* always described the CLI and the schema, the tool-agnostic half a consumer builds on. That half is unchanged; the skill layer is where git reading and the floor live.
- [`spec/v1/SPEC.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1038) — four new categories: SESSION, [BRIEF](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1094), [DURABILITY](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1113), [FALLBACK](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1132).

**One behavioral fix, easy to miss in prose.**

- [`hooks/session-nudge.sh`](https://github.com/chris-peterson/tack/pull/48/changes#diff-31e9ec4e601a092e19b57b9d6434d6587c28183e662b9c3397348c649230a4dfR40) — route resolution now retries every prompt until it binds (`.bound`), and only the nudge text debounces (`.nudged`). `UserPromptSubmit` fires before the agent acts, so a session opened with `start` was probed *before* its route existed and never looked again — unattributed for its whole life. Spec'd as [HOOK-04a](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1009)/[04b](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1019).
- [`hooks/landing-nudge.sh`](https://github.com/chris-peterson/tack/pull/48/changes#diff-99970019aa5e811f6ef5429324c3229f215639af67e02cf32d32a9c0d9d87802R28) — new: a change-request description landing prompts the handoff report, once per session.

**Skim.**

- [`SPEC.md`](https://github.com/chris-peterson/tack/pull/48/changes#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0R65) — every requirement prefix now reads as a word: `DEL`→`DELIVER`, `DEP`→`DEPENDS`, `LINK`→`LINKS`, `AGT`→`AGENT`. Nothing outside the repo reads these IDs, and they aren't one of the four surfaces `1.x` freezes.
- `STATUS.md` holds at 190/190 with the 26 new IDs.

## Approach & trade-offs

**tack declares zero outbound dependencies, and that was the design constraint rather than a happy accident.** The skills name a forge skill and a retro skill, and read the agent's own skill listing to decide whether either resolves; where one doesn't, the step is dropped and named as dropped ([FALLBACK](https://github.com/chris-peterson/tack/pull/48/changes#diff-dd72fca36fe2c5311b56928ddcd9534f6ac3e42fb2b4fb3af9b8f9f3049218b7R1132)).

The reason to care: every plugin this pair would naturally depend on — anchor, beacon, logbook — already depends on tack. Declaring any of those edges would put tack at both the bottom and the top of the same graph. Three specifics fell out of that:

| Wanted from | Instead |
|---|---|
| logbook, for the session id | the hook takes it from its own stdin, where it's reliably available |
| logbook, for a note count to judge retro-worthiness | the retro skill already reads those notes first; `end` just hands off |
| beacon, for a session label and status | the route's own state is what a fleet view reads |

The alternative was a separate plugin sitting above all of them, which buys a boundary and no capability. Cohesion won: `start` creates a route, `end` closes one.
