### PR TITLE
Generate the CLI manifest through bin/tack

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -78,8 +78,13 @@ docs:
 # contract. gen-cli-manifest runs the built CLI, parses what its help documents,
 # and writes the manifest below — which build-docs then renders as a command
 # reference page, so the page can't drift from the binary.
+#
+# It goes through `bin/tack` rather than node directly: the committed `dist/`
+# imports `yaml` at runtime, and the release job regenerates these artifacts with
+# no Node build step ahead of it, so `bin/tack`'s first-run install is what puts
+# the runtime dependencies in place.
 cli:
-  invoke: node dist/cli.js
+  invoke: bin/tack
   engine: usage-lines
   manifest: spec/cli.yml
   lede: |


### PR DESCRIPTION
## Context

The `Release` workflow can't finish. It hands off to shipyard's reusable release job, which checks out `main`, sets up Python, and runs the generators over the sources — no Node build anywhere in it. One of those generators, `gen-cli-manifest`, runs tack's CLI to record its grammar, and `plugin.yml` pointed it at `node dist/cli.js`. The committed `dist/route.js` imports `yaml` at runtime, so on a checkout with no `node_modules` that invocation exits 1 with `ERR_MODULE_NOT_FOUND` and the release dies before it commits the version bump ([the run](https://github.com/chris-peterson/tack/actions/runs/32595643099/job/97086001014)). `Project` never hit this because it does `npm ci && npm run build` first.

Pointing the manifest generator at `bin/tack` instead fixes it: `bin/tack` installs the runtime dependencies when `node_modules` is missing, then execs the same `dist/cli.js`.

## Review guide

**The change** — [`plugin.yml:87`](https://github.com/chris-peterson/tack/pull/55/changes#diff-7f611fed98d5dbe0eb481dcdaf1cc022cc422f47a313ec7983a87b9266dcc3d1R87)

## Approach & trade-offs

The gap is really in shipyard's reusable `release.yml`, which runs generators that can interrogate a built binary without offering any build step ahead of them — so every Node-CLI plugin calling it hits this. Fixing it there needs a change to another repo plus a `v2` tag move; this keeps the fix where the failing release is.

## Validation

The failure and the fix were both exercised against a clean clone with no `node_modules`, which is the release runner's state:

| Check | Result |
| --- | --- |
| `node dist/cli.js --help` | exit 1, `Cannot find package 'yaml' imported from dist/route.js` — reproduces the CI failure |
| `bin/tack --help` | exit 0, `Usage:` on stdout; the install notice goes to stderr, which the `usage-lines` engine doesn't parse |
| `shipyard generate` with `invoke: bin/tack` | exit 0, and `spec/cli.yml`, `docs/cli.md`, `plugin.json`, `hooks/hooks.json` all come out byte-identical — the recorded grammar is unchanged |
| `package-lock.json` after `bin/tack`'s install | unchanged, so the release commit's `git add -A` has nothing extra to pick up |
