### PR TITLE
Correct why the start skill skips tack session

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1052,10 +1052,10 @@ so session→route attribution does not depend on the agent remembering to run
 `tack session`.
 
 **[HOOK-04a]** Resolution per [HOOK-04] shall repeat on every prompt until it
-binds, rather than running once per session. A session opened with the `start`
-skill has no route at its first prompt — the skill creates one mid-turn — so a
-once-per-session probe would look before the route exists and never look again,
-leaving the session unattributed for its whole life.
+binds, rather than running once per session. A route becomes resolvable mid-session
+— the `start` skill creates one and cuts its branch inside a turn, and a branch can
+be cut or renamed at any later point — so a once-per-session probe would look
+before the branch it resolves by exists, and never look again.
 
 **[HOOK-04b]** When no route resolves, the hook shall emit a nudge naming the
 `start` skill as the way to open one, at most once per session. The nudge shall
@@ -1112,9 +1112,11 @@ performed by a bundled script rather than re-derived per invocation.
 fetched default branch rather than from whatever is checked out, except where
 the user states the work builds on the current branch.
 
-**[SESSION-05]** The `start` skill shall not run `tack session`. Session binding is
-the hook's responsibility per [HOOK-04], which is the only place the session id
-is reliably available.
+**[SESSION-05]** The `start` skill shall not run `tack session`. The `init` and
+`add` calls it already makes record the session on the route from
+`CLAUDE_CODE_SESSION_ID` per [CLI-02] and [CLI-04], so a separate binding call
+writes what the CLI just wrote. [HOOK-04] covers the session the skill cannot:
+one that resolves onto a route it did not create.
 
 **[SESSION-06]** The plugin shall provide an `end` skill that closes a work session
 by reading the end state fresh, holding the durability floor of the FLOOR

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -135,10 +135,9 @@ tack link add {slug} t1 "{repo} {ref}" "{issue_url}"
 
 Omit the `tack link add` when no URL was given.
 
-**Don't run `tack session`.** The `session-nudge` hook binds the session to the
-route from its own stdin, which is the only place the session id is reliably
-available — `$CLAUDE_SESSION_ID` is not exported to the shell. Creating the route
-here is what lets the hook resolve it by branch-slug match on the next prompt.
+**Don't run `tack session`.** The `tack init` and `tack add` calls above already
+record the session on the route, from `CLAUDE_CODE_SESSION_ID`, so a `tack
+session` call here writes what they just wrote.
 
 Branch-slug match is what resolves the route on later turns, so the branch you
 just cut is what keeps this session findable. **When the work has no branch of


### PR DESCRIPTION
## Context

tack records which Claude Code session is working which route, so a fleet reader can attribute a terminal window to the work it's driving. `[SESSION-05]` and the `start` skill both said that binding had to be a hook's job, because the session id is reachable only from a hook's stdin. It isn't only reachable there. `[CLI-02]` and `[CLI-04]` in the same spec file already specify that `tack init` and `tack add` record the session from `CLAUDE_CODE_SESSION_ID`, and `src/cli.test.ts` has asserted that since #23, six weeks before the skill landed saying otherwise. The requirement holds either way; what changes is the reason under it. This surfaced while designing #56, where a subscriber's handler needs to know its own session id and the false premise would have pushed that toward hook plumbing it doesn't need.

## Review guide

- [`[SESSION-05]`](https://github.com/chris-peterson/tack/pull/57/changes#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0R1115) — the correction. Same requirement, resting on `[CLI-02]` / `[CLI-04]` instead of on the claim they contradict
- [`[HOOK-04a]`](https://github.com/chris-peterson/tack/pull/57/changes#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0R1055) — carried the same premise in its rationale. Retrying every prompt is still right, now for the reason that holds: a branch can be cut or renamed at any point mid-session
- [`skills/start/SKILL.md`](https://github.com/chris-peterson/tack/pull/57/changes#diff-fbba5ae9c49f7e829a73947e305612326c8a8acd82d4a6ca8fe4f9b45026de5dR138) — the same fact where the agent reads it

No code changes. `docs/spec.md`, `docs/spec/v1.md`, and `docs/skills/start.md` carry the same sentence and are git-ignored renders, rebuilt on deploy.
